### PR TITLE
Fix install + dashboard rendering with bundled demo data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     arrow,
     circlize,
     ComplexHeatmap,
+    countrycode,
     DBI,
     dplyr,
     DT,
@@ -50,7 +51,6 @@ Imports:
     tibble,
     tidyr
 Suggests:
-    countrycode,
     knitr,
     networkD3,
     processx,

--- a/R/app.R
+++ b/R/app.R
@@ -19,33 +19,6 @@
 #'   shiny::runApp(app)
 #' }
 launchAMRDashboard <- function(results_root = NULL) {
-  # Bug choices
-  bug_choices <- c(
-    "Enterococcus faecium" = "Efa",
-    "Staphylococcus aureus" = "Sau",
-    "Klebsiella pneumoniae" = "Kpn",
-    "Acinetobacter baumannii" = "Aba",
-    "Pseudomonas aeruginosa" = "Pae",
-    "Enterobacter spp." = "Esp.",
-    "Escherichia coli" = "Eco",
-    "Campylobacter jejuni" = "Cje",
-    "Staphylococcus epidermidis" = "Sep"
-  )
-
-  # ESKAPE bugs (sorted in ESKAPE order)
-  eskape_bugs <- c(
-    "Enterococcus faecium" = "Efa",
-    "Staphylococcus aureus" = "Sau",
-    "Klebsiella pneumoniae" = "Kpn",
-    "Acinetobacter baumannii" = "Aba",
-    "Pseudomonas aeruginosa" = "Pae",
-    "Enterobacter spp." = "Esp.",
-    "Escherichia coli" = "Eco",
-    "Campylobacter jejuni" = "Cje",
-    "Staphylococcus epidermidis" = "Sep",
-    "Streptococcus pneumoniae" = "Spn"
-  )
-
   # UI
   ui <- tagList(
     shinyjs::useShinyjs(),
@@ -274,6 +247,12 @@ launchAMRDashboard <- function(results_root = NULL) {
       updateSelectizeInput(session, "bug_search_amr_across_drug",
         choices = choices, selected = sel
       )
+      updateSelectizeInput(session, "bug_cross_model_comparison_id",
+        choices = choices, selected = sel
+      )
+      updateSelectizeInput(session, "bug_holdouts_id",
+        choices = choices, selected = sel
+      )
     })
 
     # Update metadata bug selector from metadata parquets (not ML perf data)
@@ -330,16 +309,6 @@ launchAMRDashboard <- function(results_root = NULL) {
     # observe to load all the data
     observe({
       drug_class_map(loadDrugClassMapRec())
-    })
-
-    # clear the selected bug when the user changes the drug/drug class
-    observeEvent(input$across_bug_id, {
-      updateSelectInput(
-        session,
-        inputId = "bug_search_amr_across_bug",
-        choices = bug_choices,
-        selected = unname(bug_choices) # Default to ESKAPE bugs
-      )
     })
 
     observeEvent(c(input$bug_search_amr_across_bug, input$across_bug_id, input$bug_drug_comp_model_scale, input$data_type), {
@@ -777,6 +746,7 @@ launchAMRDashboard <- function(results_root = NULL) {
           input$top_n_features,
           input$feature_importance_tabset
         )
+        req(ht)
         draw(ht, heatmap_legend_side = "right")
       })
     })
@@ -800,6 +770,7 @@ launchAMRDashboard <- function(results_root = NULL) {
           input$top_n_features,
           input$feature_importance_tabset
         )
+        req(ht)
         draw(ht, heatmap_legend_side = "right")
       })
     })
@@ -815,6 +786,7 @@ launchAMRDashboard <- function(results_root = NULL) {
           input$top_n_features,
           input$feature_importance_tabset
         )
+        req(ht)
         draw(ht, heatmap_legend_side = "right")
       })
       output$feature_importance_table <- DT::renderDataTable({
@@ -898,6 +870,7 @@ launchAMRDashboard <- function(results_root = NULL) {
           input$drug_cross_model_comparison_id,
           input$cross_model_comparison
         )
+        req(ht)
         draw(ht, heatmap_legend_side = "left")
       })
       output$cross_model_feature_importance_plot <- renderPlot({
@@ -908,6 +881,7 @@ launchAMRDashboard <- function(results_root = NULL) {
           input$cross_model_comparison,
           input$cross_model_top_n_features
         )
+        req(ht)
         draw(ht, heatmap_legend_side = "left")
       })
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -481,9 +481,6 @@ makeDatAvailabilityPlot <- function(data) {
 }
 
 makeGeoChloroPlot <- function(data) {
-  if (!requireNamespace("countrycode", quietly = TRUE)) {
-    stop("Package 'countrycode' is required for this function. Install it with install.packages('countrycode').")
-  }
   data$iso3 <- countrycode::countrycode(data$genome.isolation_country, origin = "country.name", destination = "iso3c")
   plot_ly(
     data = data,
@@ -1091,9 +1088,14 @@ makeCrossModelPerformancePlot <- function(perf_data, bug, drug, cross_model) {
     return(NULL)
   }
 
+  # Widen range when all-NA or single value so ComplexHeatmap's legend stays valid
   min_val <- min(models_performance, na.rm = TRUE)
   max_val <- max(models_performance, na.rm = TRUE)
-  if (min_val == max_val) min_val <- min_val - 0.00001
+  if (!is.finite(min_val) || min_val == max_val) {
+    center <- if (is.finite(min_val)) min_val else 0.5
+    min_val <- max(0, center - 0.05)
+    max_val <- min(1, center + 0.05)
+  }
 
   row_title <- if (cross_model == "country") "Tested Country" else "Tested Year"
   col_title <- if (cross_model == "country") "Trained Country" else "Trained Year"


### PR DESCRIPTION


# Description
This PR's focus is to allow the shiny app to work on the included external data, and thus user, input, when before it was defaulting to ESKAPE pathogens. This led to the dashboards being broken and not usable

- Moved countrycode to Imports from Suggests. This was done because it was very noticable just having a major panel giving an error and would confuse a user
- Guarded `ComplexHeatmap::draw(ht...)` calls with `req` to deal with no data render on empty panels
- Removed observer on the Bug/Drug feature comparison tab that attempted to hardcode ESKAPE labels
- Fixed a crash involving the legend in `makeCrossModelPerformancePlot()` which appears when there is only one unique strat value
- Populated the Model holdouts Bug/Drug selectors to the loaded data. They were previously empty so the tab was not usable


## What kind of change(s) are included?

- [ ] Feature (adds or updates new capabilities)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [ ] I have searched for existing content to ensure this is not a duplicate.
- [ ] I have performed a self-review of these additions (including spelling, grammar, and related).
- [ ] I have added comments to my code to help provide understanding.
- [ ] I have added a test which covers the code changes found within this PR.
- [ ] I have deleted all non-relevant text in this pull request template.
- [ ] **Reviewer assignment**: Tag a relevant team member to review and approve the changes.
