### PR TITLE
README: add MCC metric and update author order per manuscript

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -129,6 +129,7 @@ Required columns:
 - `type`: Count or binary features
 - `bal_acc`: Balanced accuracy
 - `f1`: F1 score
+- `mcc`: Matthews correlation coefficient
 - `nmcc`: Normalized Matthews correlation coefficient
 - Additional columns for other metrics
 
@@ -166,7 +167,7 @@ amRviz/
 If you use `amRviz` in your research, please cite:
 
 ```
-Brenner E, Ghosh A, Wolfe E, Boyer E, Vang C, Lesiyon R, Mayer D, Ravi J. (2026).
+Brenner E, Ghosh A, Boyer E, Vang C, Wolfe E, McKim A, Lesiyon R, Mayer D, Ravi J. (2026).
 amR: an R package suite to predict antimicrobial resistance in bacterial pathogens.
 R package version 0.99.0.
 https://github.com/JRaviLab/amR

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ results/
 | `strat_value_test` | Tested-on country or year (cross models only) |
 | `bal_acc` | Balanced accuracy |
 | `f1` | F1 score |
+| `mcc` | Matthews correlation coefficient |
 | `nmcc` | Normalized Matthews correlation coefficient |
 
 ### Top features (`*_ML_top_features.parquet`)
@@ -181,7 +182,7 @@ amRviz/
 If you use `amRviz` in your research, please cite:
 
 ```
-Brenner E, Ghosh A, Wolfe E, Boyer E, Vang C, Lesiyon R, Mayer D, Ravi J. (2026).
+Brenner E, Ghosh A, Boyer E, Vang C, Wolfe E, McKim A, Lesiyon R, Mayer D, Ravi J. (2026).
 amR: an R package suite to predict antimicrobial resistance in bacterial pathogens.
 R package version 0.99.0.
 https://github.com/JRaviLab/amR


### PR DESCRIPTION
Addresses two of the README comments from @jananiravi's review on #14 (closed):

- Added `mcc` (Matthews correlation coefficient) to the performance metrics table - we're now reporting both MCC and nMCC.
- Updated the author order in the citation block based on manuscript to: Brenner E, Ghosh A, Boyer E, Vang C, Wolfe E, McKim A, Lesiyon R, Mayer D, Ravi J.

### Test plan
- Visual diff check: only two added lines per file.
- No code changes; nothing to run.