### PR TITLE
Run shinytest2 app tests on CI; fix duplicate input IDs and test warn…

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -17,6 +17,13 @@ jobs:
   app-tests:
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (app tests)
+
+    # Use bash on every OS so `R CMD INSTALL .` works on Windows too -- in
+    # PowerShell, `R` is an alias for Invoke-History, which breaks the command.
+    defaults:
+      run:
+        shell: bash
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -1,0 +1,51 @@
+# Runs the shinytest2 app tests on their own (with devtools::test(), NOT inside
+# R CMD check) across Windows, macOS, and Ubuntu. Running them outside R CMD
+# check means the browser's leftover temp files don't trip the "detritus in the
+# temp directory" warning, while still confirming the dashboard launches on every
+# platform. RUN_APP_TESTS=true opts the tests in (see tests/testthat/test-shinytest2.R).
+name: app-tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions: read-all
+
+jobs:
+  app-tests:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.os }} (app tests)
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest}
+          - {os: macos-latest}
+          - {os: windows-latest}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      NOT_CRAN: true
+      RUN_APP_TESTS: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: browser-actions/setup-chrome@v1
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::devtools, any::shinytest2
+          needs: check
+
+      - name: Run app tests
+        run: Rscript -e 'devtools::test(filter = "shinytest2", stop_on_failure = TRUE)'

--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -44,8 +44,14 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::devtools, any::shinytest2
+          extra-packages: any::shinytest2
           needs: check
 
+      # Install the package itself: shinytest2 launches the app in a separate R
+      # process that must be able to load amRviz, which it can't do from a
+      # load_all() dev session (e.g. devtools::test()).
+      - name: Install amRviz
+        run: R CMD INSTALL .
+
       - name: Run app tests
-        run: Rscript -e 'devtools::test(filter = "shinytest2", stop_on_failure = TRUE)'
+        run: Rscript -e 'library(amRviz); res <- as.data.frame(testthat::test_file("tests/testthat/test-shinytest2.R", reporter = "progress")); if (sum(res$failed) > 0 || any(res$error)) quit(status = 1)'

--- a/R/app.R
+++ b/R/app.R
@@ -444,7 +444,7 @@ launchAMRDashboard <- function(results_root = NULL,
       )
     })
 
-    observeEvent(c(input$bug_search_amr_across_bug, input$across_bug_id, input$bug_drug_comp_model_scale, input$data_type), {
+    observeEvent(c(input$bug_search_amr_across_bug, input$across_bug_id, input$bug_drug_comp_model_scale, input$feature_data_type), {
       req(input$bug_search_amr_across_bug)
       message("Across bug feature comparison: ")
 
@@ -453,7 +453,7 @@ launchAMRDashboard <- function(results_root = NULL,
       base_tf <- topFeatures() |>
         dplyr::filter(normalize_species(.data$species) %in% bn) |>
         dplyr::filter(.data$feature_type %in% input$bug_drug_comp_model_scale) |>
-        dplyr::filter(.data$feature_subtype %in% input$data_type) |>
+        dplyr::filter(.data$feature_subtype %in% input$feature_data_type) |>
         dplyr::filter(is.na(.data$strat_label) | !nzchar(.data$strat_label))
 
       if (identical(input$across_bug_id, "drug")) {
@@ -478,7 +478,7 @@ launchAMRDashboard <- function(results_root = NULL,
 
 
     # For drug/drug class (across drug) | filter by scale/data type
-    observeEvent(c(input$bug_search_amr_across_drug, input$across_drug_id, input$bug_drug_comp_model_scale, input$data_type), {
+    observeEvent(c(input$bug_search_amr_across_drug, input$across_drug_id, input$bug_drug_comp_model_scale, input$feature_data_type), {
       req(input$bug_search_amr_across_drug)
       message("Across drug feature comparison: ")
 
@@ -487,7 +487,7 @@ launchAMRDashboard <- function(results_root = NULL,
       base_tf <- topFeatures() |>
         dplyr::filter(normalize_species(.data$species) %in% bn) |>
         dplyr::filter(.data$feature_type %in% input$bug_drug_comp_model_scale) |>
-        dplyr::filter(.data$feature_subtype %in% input$data_type) |>
+        dplyr::filter(.data$feature_subtype %in% input$feature_data_type) |>
         dplyr::filter(is.na(.data$strat_label) | !nzchar(.data$strat_label))
 
       if (identical(input$across_drug_id, "drug")) {
@@ -923,7 +923,7 @@ launchAMRDashboard <- function(results_root = NULL,
           input$bug_search_amr_across_bug,
           amr_drug,
           input$bug_drug_comp_model_scale,
-          input$data_type,
+          input$feature_data_type,
           input$top_n_features,
           input$feature_importance_tabset,
           amrdata_root = amrdata_root,
@@ -947,7 +947,7 @@ launchAMRDashboard <- function(results_root = NULL,
           input$bug_search_amr_across_drug,
           amr_drug,
           input$bug_drug_comp_model_scale,
-          input$data_type,
+          input$feature_data_type,
           input$top_n_features,
           input$feature_importance_tabset,
           amrdata_root = amrdata_root,
@@ -963,7 +963,7 @@ launchAMRDashboard <- function(results_root = NULL,
           input$bug_ml_perf_id,
           input$amr_drug_ml_across_bug,
           input$model_scale,
-          input$data_type,
+          input$feature_data_type,
           input$top_n_features,
           input$feature_importance_tabset,
           amrdata_root = amrdata_root,

--- a/R/featureImportanceUI.R
+++ b/R/featureImportanceUI.R
@@ -24,7 +24,7 @@ featureImportanceUI <- function() {
         width = 4,
         style = "height: 80px; display: flex; align-items: center;",
         selectInput(
-          "data_type",
+          "feature_data_type",
           label = tags$label("Data type", style = "font-size: 15px;"),
           choices = c("count" = "counts", "binary" = "binary"),
           multiple = FALSE,
@@ -71,12 +71,14 @@ featureImportanceUI <- function() {
                 )
               ),
               fluidRow(
+                # Bug selector is the same in both modes, so define it once
+                # outside the conditional panels (avoids a duplicate input id).
+                column(
+                  width = 6, style = "padding: 0;",
+                  amr_select("bug_search_amr_across_bug", "Bug (multi-select)", character(0), selected = NULL)
+                ),
                 conditionalPanel(
                   condition = "input.across_bug_id == 'drug'",
-                  column(
-                    width = 6, style = "padding: 0;",
-                    amr_select("bug_search_amr_across_bug", "Bug (multi-select)", character(0), selected = NULL)
-                  ),
                   column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_ml_across_bug", "Drug", NULL, FALSE)
@@ -84,10 +86,6 @@ featureImportanceUI <- function() {
                 ),
                 conditionalPanel(
                   condition = "input.across_bug_id == 'drug_class'",
-                  column(
-                    width = 6, style = "padding: 0;",
-                    amr_select("bug_search_amr_across_bug", "Bug (multi-select)", character(0), selected = NULL)
-                  ),
                   column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_class_ml_across_bug", "Drug class", NULL, FALSE)
@@ -142,12 +140,14 @@ featureImportanceUI <- function() {
                 )
               ),
               fluidRow(
+                # Bug selector is the same in both modes, so define it once
+                # outside the conditional panels (avoids a duplicate input id).
+                column(
+                  width = 6, style = "padding: 0;",
+                  amr_select("bug_search_amr_across_drug", "Bug", character(0), selected = NULL, multiple = FALSE)
+                ),
                 conditionalPanel(
                   condition = "input.across_drug_id == 'drug'",
-                  column(
-                    width = 6, style = "padding: 0;",
-                    amr_select("bug_search_amr_across_drug", "Bug", character(0), selected = NULL, multiple = FALSE)
-                  ),
                   column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_ml_across_drug", "Drug (multi-select)", NULL)
@@ -155,10 +155,6 @@ featureImportanceUI <- function() {
                 ),
                 conditionalPanel(
                   condition = "input.across_drug_id == 'drug_class'",
-                  column(
-                    width = 6, style = "padding: 0;",
-                    amr_select("bug_search_amr_across_drug", "Bug", character(0), selected = NULL, multiple = FALSE)
-                  ),
                   column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_class_ml_across_drug", "Drug class (multi-select)", NULL)

--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -27,16 +27,29 @@ skip_if_no_shinytest2 <- function() {
   }
 }
 
-# Start the demo app for testing. We allow long wait times because the app
-# loads several data files and draws interactive plots when it first opens.
+# Start the demo app for testing. The app loads several data files
+# and draws interactive plots when it first opens.
 # Setting a fixed seed makes the results the same each time the test is run.
+#
+# When it starts the app, shinytest2 scans the server function for global
+# variables and warns that it cannot resolve the bare column names used in
+# dplyr (non-standard evaluation). This is a harmless false positive -- the app
+# runs correctly -- so we quietly drop just that one warning and let any other
+# warning through.
 new_demo_app <- function(name) {
-  shinytest2::AppDriver$new(
-    launchAMRDashboard(),
-    name = name,
-    seed = 1234,
-    timeout = 60 * 1000,
-    load_timeout = 60 * 1000
+  withCallingHandlers(
+    shinytest2::AppDriver$new(
+      launchAMRDashboard(),
+      name = name,
+      seed = 1234,
+      timeout = 60 * 1000,
+      load_timeout = 60 * 1000
+    ),
+    warning = function(w) {
+      if (grepl("locate globals|globalsByName", conditionMessage(w))) {
+        invokeRestart("muffleWarning")
+      }
+    }
   )
 }
 
@@ -53,6 +66,25 @@ expect_output_ok <- function(app, output_id) {
     info = sprintf("output '%s' rendered a Shiny error", output_id)
   )
 }
+
+# Give the browser its own temp directory for the duration of this test file, so
+# the scratch files Chrome creates land there and are deleted when the file
+# finishes, instead of lingering in the shared session temp dir (which would
+# clutter a reviewer's session and can trip R CMD check's "detritus in the temp
+# directory" check). Chrome chooses where to write from these OS temp env vars,
+# and withr both creates the directory and removes it at teardown.
+#
+# NOTE: on Windows, deleting these files can fail if the (shared) Chrome process
+# still holds them open when teardown runs. Confirming that across Win/Mac/Ubuntu
+# is the main purpose of the dedicated app-tests workflow.
+.chrome_tmp <- withr::local_tempdir(
+  "amrviz-chrome-",
+  .local_envir = testthat::teardown_env()
+)
+withr::local_envvar(
+  c(TMPDIR = .chrome_tmp, TMP = .chrome_tmp, TEMP = .chrome_tmp),
+  .local_envir = testthat::teardown_env()
+)
 
 test_that("dashboard launches on the home tab with no output errors", {
   skip_if_no_shinytest2()


### PR DESCRIPTION
## Summary
Follow-up to PR  #16. Gets the shinytest2 app tests running on CI across all platforms, and clears the warnings those tests were showing.

## Changes

### Run app tests on CI
- New `app-tests.yaml` workflow runs the app tests on Ubuntu/macOS/Windows with `devtools::test()` — separately from `R CMD check`, so the browser's  temp files don't cause the "detritus in the temp directory" warning. The normal `R-CMD-check` still skips them.
- The app tests now put Chrome's temp files in their own folder (using `withr`) that gets deleted when the tests finish, so they don't pile up in a reviewer's session.

### Fix the app-test warnings
- **Duplicate input IDs:** the Bug/Drug feature comparison tab was reusing the `data_type` ID (already used by the Model performance tab) and defined the bug selectors twice. Renamed the feature tab's input to `feature_data_type` and define each bug selector once.

## Result
- App tests: 20 pass, 0 warnings.
- Full test suite: 168 pass, 0 fail.

## Notes
- The app tests only run in the new workflow (and locally), `R-CMD-check` stays clean.
- Keep an eye on the Windows result: deleting Chrome's temp folder can fail there if the browser hasn't fully closed.