### PR TITLE
Add plot exports, ported amRml visualizations, and network styling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,15 +25,21 @@ Depends:
     R (>= 4.5.0)
 Imports:
     arrow,
+    circlize,
+    ComplexHeatmap,
     countrycode,
     dplyr,
     DT,
     ggplot2,
     glue,
+    grDevices,
+    grid,
     here,
+    htmlwidgets,
     networkD3,
     plotly,
     purrr,
+    RColorBrewer,
     readr,
     rlang,
     shiny,
@@ -51,12 +57,14 @@ Suggests:
     shinytest2,
     spelling,
     testthat (>= 3.0.0),
+    webshot2,
     withr
 VignetteBuilder: knitr
 biocViews:
     Software,
     FunctionalGenomics,
     Genetics,
+    GUI,
     Visualization
 URL: https://github.com/jravilab/amRviz
 BugReports: https://github.com/jravilab/amRviz/issues

--- a/R/app.R
+++ b/R/app.R
@@ -143,6 +143,22 @@ launchAMRDashboard <- function(results_root = NULL,
                       .home-tab-icon {
                         font-size: 16px;
                       }
+                      /* Small blue export buttons matching the navbar accent */
+                      .btn-export {
+                        background-color: #5b9bd5;
+                        border-color: #5b9bd5;
+                        color: #ffffff;
+                        font-size: 11px;
+                        padding: 2px 9px;
+                        border-radius: 3px;
+                      }
+                      .btn-export:hover,
+                      .btn-export:focus,
+                      .btn-export:active {
+                        background-color: #4a89c4 !important;
+                        border-color: #4a89c4 !important;
+                        color: #ffffff !important;
+                      }
                     "))
     ),
     # App header: title row separate from the nav tabs
@@ -288,6 +304,36 @@ launchAMRDashboard <- function(results_root = NULL,
     # Load performance metrics + top features based on selected species folders
     queryData <- reactiveVal(tibble::tibble())
     topFeatures <- reactiveVal(tibble::tibble())
+    mdrData <- reactiveVal(tibble::tibble())
+
+    # Static-export capture: each interactive panel stashes its latest rendered
+    # widget here (a plain env, so no reactive invalidation) so the per-panel
+    # "Export (PDF)" download can snapshot exactly what is on screen.
+    exportWidgets <- new.env(parent = emptyenv())
+    stashWidget <- function(w, id) {
+      exportWidgets[[id]] <- w
+      w
+    }
+
+    # One static-PDF download handler per interactive panel: snapshots the
+    # stashed widget (plotly / networkD3 / Sankey) to PDF via .writeWidgetStatic.
+    # Output id is "<plot id>_static_download" (paired with a button in the UI).
+    lapply(c(
+      "metadata_sankey", "resistance_vs_susceptible_plot", "geo_isolate_plot",
+      "r_s_across_time_plot", "host_isolate_plot", "isolation_source_plot",
+      "model_perfomance_plot", "nmcc_strip_plot", "nmcc_heatmap",
+      "mdr_performance_plot", "across_drug_vi_plot", "across_bug_cog_barplot",
+      "across_drug_cog_barplot", "across_bug_ego_network",
+      "across_drug_ego_network", "cross_model_ridge_country",
+      "cross_model_ridge_time", "drug_feature_network"
+    ), function(id) {
+      output[[paste0(id, "_static_download")]] <- downloadHandler(
+        filename = function() paste0(id, "_", Sys.Date(), ".pdf"),
+        content = function(file) {
+          .writeWidgetStatic(file, exportWidgets[[id]])
+        }
+      )
+    })
 
     observeEvent(
       list(results_root, input$results_species_dirs),
@@ -308,6 +354,10 @@ launchAMRDashboard <- function(results_root = NULL,
 
         queryData(perf)
         topFeatures(top)
+        mdrData(loadMDRResults(
+          results_root = results_root,
+          species_dirs = input$results_species_dirs
+        ))
       },
       ignoreInit = FALSE
     )
@@ -691,7 +741,10 @@ launchAMRDashboard <- function(results_root = NULL,
       if (is.null(meta) || !nrow(meta)) {
         return(NULL)
       }
-      makeMetadataSankey(meta, drug_classes = input$metadata_sankey_classes)
+      stashWidget(
+        makeMetadataSankey(meta, drug_classes = input$metadata_sankey_classes),
+        "metadata_sankey"
+      )
     })
 
     ## get a quick summary plot;
@@ -728,7 +781,10 @@ launchAMRDashboard <- function(results_root = NULL,
             }
           }
         )
-        makeDatAvailabilityPlot(metadata)
+        stashWidget(
+          makeDatAvailabilityPlot(metadata),
+          "resistance_vs_susceptible_plot"
+        )
       })
     })
 
@@ -767,7 +823,7 @@ launchAMRDashboard <- function(results_root = NULL,
         dplyr::summarise(count = sum(count), .groups = "drop") |>
         dplyr::collect()
 
-      makeGeoChloroPlot(data)
+      stashWidget(makeGeoChloroPlot(data), "geo_isolate_plot")
     })
 
     output$r_s_across_time_plot <- plotly::renderPlotly({
@@ -808,7 +864,10 @@ launchAMRDashboard <- function(results_root = NULL,
         summarize(n = n()) |>
         dplyr::collect()
       # print(data)
-      makeTimeSeriesAMRPlot(data, input$amr_drug_search)
+      stashWidget(
+        makeTimeSeriesAMRPlot(data, input$amr_drug_search),
+        "r_s_across_time_plot"
+      )
     })
 
     output$host_isolate_plot <- plotly::renderPlotly({
@@ -842,7 +901,7 @@ launchAMRDashboard <- function(results_root = NULL,
         ) |>
         dplyr::collect()
 
-      makeHostIsolatePlot(data)
+      stashWidget(makeHostIsolatePlot(data), "host_isolate_plot")
     })
 
     output$isolation_source_plot <- plotly::renderPlotly({
@@ -875,37 +934,51 @@ launchAMRDashboard <- function(results_root = NULL,
           )
         ) |>
         dplyr::collect()
-      makeIsolationSourcesPlot(data)
+      stashWidget(makeIsolationSourcesPlot(data), "isolation_source_plot")
     })
 
 
     ## ML Metrics
     # plotly::renderPlotly
     output$model_perfomance_plot <- plotly::renderPlotly({
-      makeModelPerformancePlot(
-        queryData(),
-        input$bug_ml_perf_id,
-        input$model_scale,
-        input$data_type,
-        input$model_metrics,
-        input$drug_class_ml_perf_id,
-        input$drug_ml_perf_id
+      stashWidget(
+        makeModelPerformancePlot(
+          queryData(),
+          input$bug_ml_perf_id,
+          input$model_scale,
+          input$data_type,
+          input$model_metrics,
+          input$drug_class_ml_perf_id,
+          input$drug_ml_perf_id
+        ),
+        "model_perfomance_plot"
       )
     })
 
     # Performance overview tab
     output$nmcc_strip_plot <- plotly::renderPlotly({
-      makeNmccStripPlot(
-        queryData(),
-        selected_drug_class = input$drug_class_ml_perf_id,
-        selected_drug       = input$drug_ml_perf_id
+      stashWidget(
+        makeNmccStripPlot(
+          queryData(),
+          selected_drug_class = input$drug_class_ml_perf_id,
+          selected_drug       = input$drug_ml_perf_id
+        ),
+        "nmcc_strip_plot"
       )
     })
     output$nmcc_heatmap <- plotly::renderPlotly({
-      makeNmccHeatmap(
-        queryData(),
-        selected_drug_class = input$drug_class_ml_perf_id
+      stashWidget(
+        makeNmccHeatmap(
+          queryData(),
+          selected_drug_class = input$drug_class_ml_perf_id
+        ),
+        "nmcc_heatmap"
       )
+    })
+
+    # MDR models tab: nMCC distribution of multi-drug-resistance models.
+    output$mdr_performance_plot <- plotly::renderPlotly({
+      stashWidget(makeMDRPerformancePlot(mdrData()), "mdr_performance_plot")
     })
 
     observe({
@@ -952,6 +1025,31 @@ launchAMRDashboard <- function(results_root = NULL,
           input$feature_importance_tabset,
           amrdata_root = amrdata_root,
           results_root = results_root
+        )
+      })
+    })
+
+    # Signed top-feature importance bar for the across-drug selection.
+    observe({
+      output$across_drug_vi_plot <- plotly::renderPlotly({
+        if (is.null(input$across_drug_id)) {
+          return(NULL)
+        }
+        amr_drug <- if (input$across_drug_id == "drug") {
+          input$amr_drug_ml_across_drug
+        } else {
+          input$amr_drug_class_ml_across_drug
+        }
+        stashWidget(
+          makeTopFeatsVIPlot(
+            topFeatures(),
+            input$bug_search_amr_across_drug,
+            amr_drug,
+            input$bug_drug_comp_model_scale,
+            input$feature_data_type,
+            input$top_n_features
+          ),
+          "across_drug_vi_plot"
         )
       })
     })
@@ -1047,10 +1145,14 @@ launchAMRDashboard <- function(results_root = NULL,
 
     # COG bar charts - top COGs across the currently displayed features
     output$across_bug_cog_barplot <- plotly::renderPlotly({
-      makeCogBarChart(enriched_across_bug())
+      stashWidget(
+        makeCogBarChart(enriched_across_bug()), "across_bug_cog_barplot"
+      )
     })
     output$across_drug_cog_barplot <- plotly::renderPlotly({
-      makeCogBarChart(enriched_across_drug())
+      stashWidget(
+        makeCogBarChart(enriched_across_drug()), "across_drug_cog_barplot"
+      )
     })
 
     # Ego networks - reacts to selected row in each table
@@ -1058,17 +1160,21 @@ launchAMRDashboard <- function(results_root = NULL,
       tf <- enriched_across_bug()
       sel <- input$across_bug_feature_importance_table_rows_selected
       if (is.null(tf) || !nrow(tf) || is.null(sel) || !length(sel)) {
-        return(NULL)
+        return(stashWidget(NULL, "across_bug_ego_network"))
       }
-      makeFeatureEgoNetwork(tf, tf$Variable[sel])
+      stashWidget(
+        makeFeatureEgoNetwork(tf, tf$Variable[sel]), "across_bug_ego_network"
+      )
     })
     output$across_drug_ego_network <- networkD3::renderForceNetwork({
       tf <- enriched_across_drug()
       sel <- input$across_drug_feature_importance_table_rows_selected
       if (is.null(tf) || !nrow(tf) || is.null(sel) || !length(sel)) {
-        return(NULL)
+        return(stashWidget(NULL, "across_drug_ego_network"))
       }
-      makeFeatureEgoNetwork(tf, tf$Variable[sel])
+      stashWidget(
+        makeFeatureEgoNetwork(tf, tf$Variable[sel]), "across_drug_ego_network"
+      )
     })
 
     # Cross model feature importance table
@@ -1102,22 +1208,49 @@ launchAMRDashboard <- function(results_root = NULL,
       ignoreInit = FALSE
     )
 
+    # Drug -> class map for the selected species, shared by the cross-drug
+    # plotly panel and the ComplexHeatmap export so the parquet is read once.
+    cross_drug_meta <- reactive({
+      req(input$bug_cross_model_comparison_id)
+      load_drug_class_map(
+        input$bug_cross_model_comparison_id,
+        results_root = results_root
+      )
+    })
+
+    # Cross-drug heatmap as a static ComplexHeatmap, used for the
+    # publication-quality PDF export (the dashboard panel renders plotly).
+    cross_drug_hm <- reactive({
+      req(input$bug_cross_model_comparison_id)
+      makeCrossDrugHeatmap(
+        queryData(),
+        meta = cross_drug_meta(),
+        bug = input$bug_cross_model_comparison_id
+      )
+    })
+
     observe({
       # Ridge plots - always show both country and time side by side
       output$cross_model_ridge_country <- plotly::renderPlotly({
         req(input$bug_cross_model_comparison_id)
-        makeCrossModelRidgePlot(
-          queryData(),
-          input$bug_cross_model_comparison_id,
-          "country"
+        stashWidget(
+          makeCrossModelRidgePlot(
+            queryData(),
+            input$bug_cross_model_comparison_id,
+            "country"
+          ),
+          "cross_model_ridge_country"
         )
       })
       output$cross_model_ridge_time <- plotly::renderPlotly({
         req(input$bug_cross_model_comparison_id)
-        makeCrossModelRidgePlot(
-          queryData(),
-          input$bug_cross_model_comparison_id,
-          "time"
+        stashWidget(
+          makeCrossModelRidgePlot(
+            queryData(),
+            input$bug_cross_model_comparison_id,
+            "time"
+          ),
+          "cross_model_ridge_time"
         )
       })
 
@@ -1161,16 +1294,30 @@ launchAMRDashboard <- function(results_root = NULL,
         )
       })
 
+      # Cross-drug heatmap: interactive plotly in the dashboard (the static
+      # ComplexHeatmap is reserved for the PDF export below).
+      output$cross_drug_heatmap <- plotly::renderPlotly({
+        req(input$bug_cross_model_comparison_id)
+        makeCrossDrugHeatmapPlotly(
+          queryData(),
+          meta = cross_drug_meta(),
+          bug = input$bug_cross_model_comparison_id
+        )
+      })
+
       # Drug-feature network
       output$drug_feature_network <- networkD3::renderForceNetwork({
         req(input$network_bug_id, input$network_top_n)
-        makeDrugFeatureNetwork(
-          topFeatures(),
-          input$network_bug_id,
-          top_n = input$network_top_n,
-          include_clusters = isTRUE(input$network_include_clusters),
-          include_cogs = isTRUE(input$network_include_cogs),
-          results_root = results_root
+        stashWidget(
+          makeDrugFeatureNetwork(
+            topFeatures(),
+            input$network_bug_id,
+            top_n = input$network_top_n,
+            include_clusters = isTRUE(input$network_include_clusters),
+            include_cogs = isTRUE(input$network_include_cogs),
+            results_root = results_root
+          ),
+          "drug_feature_network"
         )
       })
 
@@ -1268,6 +1415,103 @@ launchAMRDashboard <- function(results_root = NULL,
           } else {
             write.csv(data[, selected_columns, drop = FALSE], file, row.names = FALSE) # Filter columns in downloaded file
           }
+        }
+      )
+
+      # Publication-quality export of the cross-drug generalization heatmap
+      output$cross_drug_heatmap_download <- downloadHandler(
+        filename = function() {
+          paste0(
+            "cross_drug_",
+            input$bug_cross_model_comparison_id, "_", Sys.Date(), ".pdf"
+          )
+        },
+        content = function(file) {
+          .writeHeatmapPdf(
+            file, cross_drug_hm(),
+            width = 8, height = 7,
+            empty_msg =
+              "No cross-drug generalization data available for this selection."
+          )
+        }
+      )
+
+      # Publication-quality ComplexHeatmap PDF exports for the dashboard's
+      # heatmap panels. Each re-derives the plotly heatmap for the current
+      # selection and converts it via makeHeatmapExport().
+      output$across_bug_fi_download <- downloadHandler(
+        filename = function() paste0("feature_importance_across_bug_", Sys.Date(), ".pdf"),
+        content = function(file) {
+          amr_drug <- if (identical(input$across_bug_id, "drug")) {
+            input$amr_drug_ml_across_bug
+          } else {
+            input$amr_drug_class_ml_across_bug
+          }
+          p <- makeFeatureImportancePlot(
+            topFeatures(), input$bug_search_amr_across_bug, amr_drug,
+            input$bug_drug_comp_model_scale, input$feature_data_type,
+            input$top_n_features, "across_bug",
+            amrdata_root = amrdata_root, results_root = results_root
+          )
+          .writeHeatmapPdf(file, makeHeatmapExport(
+            p,
+            name = "Importance", row_title = "Feature", column_title = "Bug"
+          ))
+        }
+      )
+
+      output$across_drug_fi_download <- downloadHandler(
+        filename = function() paste0("feature_importance_across_drug_", Sys.Date(), ".pdf"),
+        content = function(file) {
+          amr_drug <- if (identical(input$across_drug_id, "drug")) {
+            input$amr_drug_ml_across_drug
+          } else {
+            input$amr_drug_class_ml_across_drug
+          }
+          p <- makeFeatureImportancePlot(
+            topFeatures(), input$bug_search_amr_across_drug, amr_drug,
+            input$bug_drug_comp_model_scale, input$feature_data_type,
+            input$top_n_features, "across_drug",
+            amrdata_root = amrdata_root, results_root = results_root
+          )
+          .writeHeatmapPdf(file, makeHeatmapExport(
+            p,
+            name = "Importance", row_title = "Feature", column_title = "Drug"
+          ))
+        }
+      )
+
+      output$cross_model_fi_download <- downloadHandler(
+        filename = function() paste0("cross_model_feature_importance_", Sys.Date(), ".pdf"),
+        content = function(file) {
+          p <- makeCrossModelFeatureImportancePlot(
+            topFeatures(), input$bug_cross_model_comparison_id,
+            input$drug_cross_model_comparison_id, input$cross_model_comparison,
+            input$cross_model_top_n_features
+          )
+          .writeHeatmapPdf(file, makeHeatmapExport(p, name = "Importance"))
+        }
+      )
+
+      output$cross_model_perf_country_download <- downloadHandler(
+        filename = function() paste0("cross_model_perf_country_", Sys.Date(), ".pdf"),
+        content = function(file) {
+          p <- makeCrossModelPerformancePlot(
+            queryData(), input$bug_cross_model_comparison_id,
+            input$drug_cross_model_comparison_id, "country"
+          )
+          .writeHeatmapPdf(file, makeHeatmapExport(p, name = "nMCC"))
+        }
+      )
+
+      output$cross_model_perf_time_download <- downloadHandler(
+        filename = function() paste0("cross_model_perf_time_", Sys.Date(), ".pdf"),
+        content = function(file) {
+          p <- makeCrossModelPerformancePlot(
+            queryData(), input$bug_cross_model_comparison_id,
+            input$drug_cross_model_comparison_id, "time"
+          )
+          .writeHeatmapPdf(file, makeHeatmapExport(p, name = "nMCC"))
         }
       )
     })

--- a/R/crossModelComparisonUI.R
+++ b/R/crossModelComparisonUI.R
@@ -68,15 +68,17 @@ crossModelComparisonUI <- function() {
               style = "padding: 10px;",
               column(
                 width = 6,
+                .exportBtn("cross_model_ridge_country"),
                 plotly::plotlyOutput("cross_model_ridge_country",
-                  height = "400px"
+                  height = "370px"
                 ),
                 style = "padding: 5px; border: 1px solid lightgray;"
               ),
               column(
                 width = 6,
+                .exportBtn("cross_model_ridge_time"),
                 plotly::plotlyOutput("cross_model_ridge_time",
-                  height = "400px"
+                  height = "370px"
                 ),
                 style = "padding: 5px; border: 1px solid lightgray;"
               )
@@ -89,15 +91,29 @@ crossModelComparisonUI <- function() {
               style = "padding: 10px;",
               column(
                 width = 6,
+                div(
+                  style = "text-align: right; padding-bottom: 4px;",
+                  downloadButton(
+                    "cross_model_perf_country_download", "Export (PDF)",
+                    class = "btn btn-export"
+                  )
+                ),
                 plotly::plotlyOutput("cross_model_perf_country",
-                  height = "400px"
+                  height = "360px"
                 ),
                 style = "padding: 5px; border: 1px solid lightgray;"
               ),
               column(
                 width = 6,
+                div(
+                  style = "text-align: right; padding-bottom: 4px;",
+                  downloadButton(
+                    "cross_model_perf_time_download", "Export (PDF)",
+                    class = "btn btn-export"
+                  )
+                ),
                 plotly::plotlyOutput("cross_model_perf_time",
-                  height = "400px"
+                  height = "360px"
                 ),
                 style = "padding: 5px; border: 1px solid lightgray;"
               )
@@ -123,9 +139,16 @@ crossModelComparisonUI <- function() {
               fluidRow(
                 column(
                   width = 6,
+                  div(
+                    style = "text-align: right; padding: 4px;",
+                    downloadButton(
+                      "cross_model_fi_download", "Export (PDF)",
+                      class = "btn btn-export"
+                    )
+                  ),
                   plotly::plotlyOutput(
                     "cross_model_feature_importance_plot",
-                    height = "100%"
+                    height = "92%"
                   ),
                   style = paste0(
                     "padding: 0; height: 400px;",
@@ -142,6 +165,34 @@ crossModelComparisonUI <- function() {
                     " margin-bottom: 20px;",
                     " border: 1px solid lightgray;"
                   )
+                )
+              )
+            )
+          ),
+          # Tab 4: Cross-drug (static ComplexHeatmap)
+          tabPanel(
+            "Cross-drug",
+            tagList(
+              fluidRow(
+                style = "padding: 10px;",
+                column(
+                  width = 12,
+                  align = "right",
+                  downloadButton(
+                    outputId = "cross_drug_heatmap_download",
+                    label = "Export (PDF)",
+                    class = "btn btn-export"
+                  )
+                )
+              ),
+              fluidRow(
+                style = "padding: 10px;",
+                column(
+                  width = 12,
+                  shinycssloaders::withSpinner(
+                    plotly::plotlyOutput("cross_drug_heatmap", height = "550px")
+                  ),
+                  style = "padding: 5px; border: 1px solid lightgray;"
                 )
               )
             )

--- a/R/featureImportanceUI.R
+++ b/R/featureImportanceUI.R
@@ -29,7 +29,7 @@ featureImportanceUI <- function() {
           choices = c("count" = "counts", "binary" = "binary"),
           multiple = FALSE,
           selectize = TRUE,
-          selected = c("counts", "binary")
+          selected = "counts"
         )
       ),
       column(
@@ -95,7 +95,14 @@ featureImportanceUI <- function() {
               column(
                 width = 6,
                 style = "padding: 0; height: 600px; border: 1px solid lightgray;",
-                plotly::plotlyOutput("across_bug_feature_importance_plot", height = "100%", width = "100%")
+                div(
+                  style = "text-align: right; padding: 4px;",
+                  downloadButton(
+                    "across_bug_fi_download", "Export (PDF)",
+                    class = "btn btn-export"
+                  )
+                ),
+                plotly::plotlyOutput("across_bug_feature_importance_plot", height = "92%", width = "100%")
               ),
               column(
                 width = 6,
@@ -107,11 +114,33 @@ featureImportanceUI <- function() {
                 column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
-                  plotly::plotlyOutput("across_bug_cog_barplot", height = "100%")
+                  .exportBtn("across_bug_cog_barplot"),
+                  plotly::plotlyOutput("across_bug_cog_barplot", height = "90%")
                 ),
                 column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
+                  .exportBtn("across_bug_ego_network"),
+                  conditionalPanel(
+                    condition = paste0(
+                      "!input.across_bug_feature_importance_table_rows_selected",
+                      " || input.across_bug_feature_importance_table",
+                      "_rows_selected.length === 0"
+                    ),
+                    div(
+                      class = "ego-network-hint",
+                      style = paste0(
+                        "padding: 14px; margin: 10px; border-radius: 5px;",
+                        " background-color: #eef4fb; color: #2b5a87;",
+                        " font-size: 13px; text-align: center;"
+                      ),
+                      icon("circle-info"),
+                      paste0(
+                        " Select a feature (row) from the table above to",
+                        " generate its interaction network here."
+                      )
+                    )
+                  ),
                   networkD3::forceNetworkOutput("across_bug_ego_network", height = "100%")
                 )
               )
@@ -162,9 +191,16 @@ featureImportanceUI <- function() {
                 )
               ),
               column(
-                width = 6, style = "padding: 0;",
-                plotly::plotlyOutput("across_drug_feature_importance_plot", height = "100%"),
-                style = "padding: 0; height: 600px; border: 1px solid lightgray;"
+                width = 6,
+                style = "padding: 0; height: 600px; border: 1px solid lightgray;",
+                div(
+                  style = "text-align: right; padding: 4px;",
+                  downloadButton(
+                    "across_drug_fi_download", "Export (PDF)",
+                    class = "btn btn-export"
+                  )
+                ),
+                plotly::plotlyOutput("across_drug_feature_importance_plot", height = "92%")
               ),
               column(
                 width = 6,
@@ -176,12 +212,43 @@ featureImportanceUI <- function() {
                 column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
-                  plotly::plotlyOutput("across_drug_cog_barplot", height = "100%")
+                  .exportBtn("across_drug_cog_barplot"),
+                  plotly::plotlyOutput("across_drug_cog_barplot", height = "90%")
                 ),
                 column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
+                  .exportBtn("across_drug_ego_network"),
+                  conditionalPanel(
+                    condition = paste0(
+                      "!input.across_drug_feature_importance_table_rows_selected",
+                      " || input.across_drug_feature_importance_table",
+                      "_rows_selected.length === 0"
+                    ),
+                    div(
+                      class = "ego-network-hint",
+                      style = paste0(
+                        "padding: 14px; margin: 10px; border-radius: 5px;",
+                        " background-color: #eef4fb; color: #2b5a87;",
+                        " font-size: 13px; text-align: center;"
+                      ),
+                      icon("circle-info"),
+                      paste0(
+                        " Select a feature (row) from the table above to",
+                        " generate its interaction network here."
+                      )
+                    )
+                  ),
                   networkD3::forceNetworkOutput("across_drug_ego_network", height = "100%")
+                )
+              ),
+              fluidRow(
+                style = "padding: 10px 0;",
+                column(
+                  width = 12,
+                  style = "padding: 0; border: 1px solid lightgray; height: 400px;",
+                  .exportBtn("across_drug_vi_plot"),
+                  plotly::plotlyOutput("across_drug_vi_plot", height = "92%")
                 )
               )
             )

--- a/R/metadataUI.R
+++ b/R/metadataUI.R
@@ -38,6 +38,7 @@ metadataUI <- function() {
               style = "text-align: center; font-family: 'Arial', sans-serif; font-size: 14px; margin-top: 8px; margin-bottom: 8px;",
               "Distribution of AMR phenotypes"
             ),
+            .exportBtn("resistance_vs_susceptible_plot"),
             styledBox("resistance_vs_susceptible_ui")
           )
         ),
@@ -50,6 +51,7 @@ metadataUI <- function() {
               style = "text-align: center; font-family: 'Arial', sans-serif; font-size: 14px; margin-top: 8px; margin-bottom: 8px;",
               "Global distribution of resistant phenotypes"
             ),
+            .exportBtn("geo_isolate_plot"),
             styledBox("geo_isolate_plot_ui")
           )
         )
@@ -64,6 +66,7 @@ metadataUI <- function() {
               style = "text-align: center; font-family: 'Arial', sans-serif; font-size: 14px; margin-top: 8px; margin-bottom: 8px;",
               "Distribution of AMR phenotypes by year"
             ),
+            .exportBtn("r_s_across_time_plot"),
             styledBox("r_s_across_time_ui")
           )
         ),
@@ -77,10 +80,12 @@ metadataUI <- function() {
               width = 12,
               tabPanel(
                 "Isolation sources",
+                .exportBtn("isolation_source_plot"),
                 styledBox("isolation_source_ui")
               ),
               tabPanel(
                 "Hosts",
+                .exportBtn("host_isolate_plot"),
                 styledBox("host_isolate_plot_ui")
               )
             )
@@ -119,6 +124,7 @@ metadataUI <- function() {
                 width = "100%"
               )
             ),
+            .exportBtn("metadata_sankey"),
             shinycssloaders::withSpinner(
               networkD3::sankeyNetworkOutput(
                 "metadata_sankey",

--- a/R/modelPerfUI.R
+++ b/R/modelPerfUI.R
@@ -81,6 +81,7 @@ modelPerfUI <- function() {
               ),
               column(
                 width = 12,
+                .exportBtn("model_perfomance_plot"),
                 div(
                   style = "height: 600px;",
                   plotly::plotlyOutput("model_perfomance_plot", height = "100%")
@@ -99,14 +100,32 @@ modelPerfUI <- function() {
                 "molecular scale, and data encoding."
               ),
               fluidRow(
-                column(4, plotly::plotlyOutput(
-                  "nmcc_strip_plot",
-                  height = "420px"
-                )),
-                column(8, plotly::plotlyOutput(
-                  "nmcc_heatmap",
-                  height = "420px"
-                ))
+                column(
+                  4,
+                  .exportBtn("nmcc_strip_plot"),
+                  plotly::plotlyOutput("nmcc_strip_plot", height = "390px")
+                ),
+                column(
+                  8,
+                  .exportBtn("nmcc_heatmap"),
+                  plotly::plotlyOutput("nmcc_heatmap", height = "390px")
+                )
+              )
+            )
+          ),
+          tabPanel(
+            "MDR models",
+            fluidPage(
+              tags$p(
+                style = "color: #555; font-size: 10px; padding-top: 10px;",
+                "Multi-drug-resistance (MDR) model performance (nMCC) by ",
+                "molecular scale; points coloured by data encoding. Shows all ",
+                "loaded MDR models."
+              ),
+              .exportBtn("mdr_performance_plot"),
+              div(
+                style = "height: 560px;",
+                plotly::plotlyOutput("mdr_performance_plot", height = "100%")
               )
             )
           )

--- a/R/networkUI.R
+++ b/R/networkUI.R
@@ -71,6 +71,7 @@ networkUI <- function() {
       fluidRow(
         column(
           width = 12,
+          .exportBtn("drug_feature_network"),
           shinycssloaders::withSpinner(
             networkD3::forceNetworkOutput(
               "drug_feature_network",

--- a/R/plots_crossmodel.R
+++ b/R/plots_crossmodel.R
@@ -250,3 +250,262 @@ makeCrossModelPerformancePlot <- function(perf_data, bug, drug, cross_model) {
       margin = list(l = 100, b = 60, t = 50)
     )
 }
+
+
+# .buildCrossDrugMatrix: shared data prep for the cross-drug heatmaps.
+# Builds an ordered trained-on (rows) x tested-on (cols) matrix of median nMCC,
+# restricted to individual drugs (drug_label == "drug"); drug classes are
+# excluded. The diagonal (train == test) is filled from the within-drug
+# baseline models. Adapted from amRml::plotCrossDrug() to amRviz's parquet
+# schema (ref_drug/test_drug/nmcc in place of drug_or_class/tested_on/mcc).
+#
+# perf_data: pre-loaded performance tibble (baseline + cross rows) as returned
+#   by loadMLResults(). Cross-drug rows have cross_test == TRUE with ref_drug /
+#   test_drug populated; baseline rows have cross_test == FALSE, strat_label NA.
+# meta: optional tibble mapping drug abbreviation -> class abbreviation, with
+#   columns drug_abbr and class_abbr (e.g. from a *_metadata.parquet); used to
+#   group rows/columns by class.
+# bug: optional species filter (matched via normalize_species()).
+#
+# Returns list(mat, class_of) with the ordered matrix and a label -> class
+# lookup, or NULL when there are no cross-drug rows to plot.
+.buildCrossDrugMatrix <- function(perf_data, meta = NULL, bug = NULL) {
+  if (is.null(perf_data) || !is.data.frame(perf_data) || !nrow(perf_data)) {
+    return(NULL)
+  }
+  required_cols <- c(
+    "cross_test", "ref_drug", "test_drug", "nmcc", "drug_or_class",
+    "drug_label", "strat_label"
+  )
+  if (!all(required_cols %in% names(perf_data))) {
+    return(NULL)
+  }
+
+  # Restrict to the selected species. Cross-drug rows are stored with
+  # species == "cross", so a plain species filter would drop them; resolve the
+  # chosen species code to its species_label (the directory name shared by the
+  # baseline and cross rows) and filter on that when available.
+  df <- perf_data
+  if (!is.null(bug)) {
+    if ("species_label" %in% names(df)) {
+      labs <- df |>
+        dplyr::filter(normalize_species(.data$species) %in% normalize_species(bug)) |>
+        dplyr::pull(.data$species_label) |>
+        unique()
+      if (length(labs)) {
+        df <- df |> dplyr::filter(.data$species_label %in% labs)
+      }
+    } else {
+      df <- df |>
+        dplyr::filter(normalize_species(.data$species) %in% normalize_species(bug))
+    }
+  }
+  if (!nrow(df)) {
+    return(NULL)
+  }
+
+  # Cross-drug cells: trained on ref_drug, tested on test_drug. Restricted to
+  # individual drugs (drug_label == "drug"); drug classes are excluded.
+  cross <- df |>
+    dplyr::filter(
+      .data$cross_test %in% TRUE,
+      .data$drug_label == "drug",
+      !is.na(.data$ref_drug), !is.na(.data$test_drug)
+    ) |>
+    dplyr::group_by(trained_on = .data$ref_drug, tested_on = .data$test_drug) |>
+    dplyr::summarise(
+      median_nmcc = stats::median(.data$nmcc, na.rm = TRUE),
+      .groups = "drop"
+    )
+  if (!nrow(cross)) {
+    return(NULL)
+  }
+
+  # Self-evaluation diagonal from the within-drug baseline models.
+  drugs <- base::union(cross$trained_on, cross$tested_on)
+  diag_df <- df |>
+    dplyr::filter(
+      .data$cross_test %in% FALSE, is.na(.data$strat_label),
+      .data$drug_label == "drug",
+      .data$drug_or_class %in% drugs
+    ) |>
+    dplyr::group_by(.data$drug_or_class) |>
+    dplyr::summarise(
+      median_nmcc = stats::median(.data$nmcc, na.rm = TRUE),
+      .groups = "drop"
+    ) |>
+    dplyr::transmute(
+      trained_on = .data$drug_or_class,
+      tested_on = .data$drug_or_class, .data$median_nmcc
+    )
+
+  # Collapse any duplicate train/test pairs so the matrix has one value per cell.
+  heatmap_df <- dplyr::bind_rows(cross, diag_df) |>
+    dplyr::group_by(.data$trained_on, .data$tested_on) |>
+    dplyr::summarise(
+      median_nmcc = stats::median(.data$median_nmcc, na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  mat <- heatmap_df |>
+    tidyr::pivot_wider(names_from = "tested_on", values_from = "median_nmcc") |>
+    tibble::column_to_rownames("trained_on") |>
+    as.matrix()
+  if (!length(mat)) {
+    return(NULL)
+  }
+
+  # Map each drug label to its class for ordering + annotation.
+  class_map <- NULL
+  if (!is.null(meta) && all(c("drug_abbr", "class_abbr") %in% names(meta))) {
+    class_map <- meta |> dplyr::distinct(.data$drug_abbr, .data$class_abbr)
+  }
+  labels <- base::union(rownames(mat), colnames(mat))
+  class_of <- stats::setNames(rep(NA_character_, length(labels)), labels)
+  if (!is.null(class_map)) {
+    hit <- match(labels, class_map$drug_abbr)
+    class_of[!is.na(hit)] <- class_map$class_abbr[hit[!is.na(hit)]]
+  }
+
+  # Order rows/columns by class, then alphabetically within class.
+  row_order <- rownames(mat)[order(class_of[rownames(mat)], rownames(mat))]
+  col_order <- colnames(mat)[order(class_of[colnames(mat)], colnames(mat))]
+  mat <- mat[row_order, col_order, drop = FALSE]
+
+  list(mat = mat, class_of = class_of)
+}
+
+# .crossDrugColorScale: shared diverging colour scaling for both cross-drug
+# heatmaps. Centres an RdBu ramp (low nMCC red -> high blue) on 0.5 (random
+# performance) with a symmetric radius derived from the finite matrix values,
+# so the static export and the interactive panel are calibrated identically.
+# n = number of colour steps. Returns list(colors, lo, hi), or NULL when the
+# matrix has no finite values.
+.crossDrugColorScale <- function(mat, n = 100) {
+  finite_vals <- mat[is.finite(mat)]
+  if (!length(finite_vals)) {
+    return(NULL)
+  }
+  rad <- max(abs(range(finite_vals) - 0.5))
+  if (!is.finite(rad) || rad == 0) {
+    rad <- 0.5
+  }
+  colors <- grDevices::colorRampPalette(
+    RColorBrewer::brewer.pal(11, "RdBu")
+  )(n)
+  list(colors = colors, lo = 0.5 - rad, hi = 0.5 + rad)
+}
+
+# makeCrossDrugHeatmap: static ComplexHeatmap of cross-drug generalization, used
+# for the publication-quality PDF export. This is the package's ComplexHeatmap
+# (Bioconductor) visualization. Arguments match .buildCrossDrugMatrix(). Returns
+# a ComplexHeatmap::Heatmap object, or NULL when there are no cross-drug rows.
+makeCrossDrugHeatmap <- function(perf_data, meta = NULL, bug = NULL) {
+  prep <- .buildCrossDrugMatrix(perf_data, meta = meta, bug = bug)
+  if (is.null(prep)) {
+    return(NULL)
+  }
+  mat <- prep$mat
+  class_of <- prep$class_of
+  row_order <- rownames(mat)
+  col_order <- colnames(mat)
+
+  # Diverging colour scale centred on 0.5 (random performance for nMCC).
+  scale <- .crossDrugColorScale(mat)
+  if (is.null(scale)) {
+    return(NULL)
+  }
+  col_fun <- circlize::colorRamp2(
+    seq(scale$lo, scale$hi, length.out = length(scale$colors)),
+    scale$colors
+  )
+
+  # Optional class annotations on rows and columns, sharing one colour key.
+  left_anno <- NULL
+  top_anno <- NULL
+  classes <- sort(unique(stats::na.omit(class_of)))
+  if (length(classes)) {
+    class_colors <- stats::setNames(
+      grDevices::hcl.colors(length(classes), palette = "Dark 3"),
+      classes
+    )
+    left_anno <- ComplexHeatmap::rowAnnotation(
+      class = class_of[row_order],
+      col = list(class = class_colors),
+      show_annotation_name = FALSE, show_legend = FALSE, na_col = "grey80"
+    )
+    top_anno <- ComplexHeatmap::HeatmapAnnotation(
+      class = class_of[col_order],
+      col = list(class = class_colors),
+      show_annotation_name = FALSE, show_legend = TRUE, na_col = "grey80"
+    )
+  }
+
+  ComplexHeatmap::Heatmap(
+    mat,
+    name = "median\nnMCC",
+    col = col_fun,
+    cluster_rows = FALSE,
+    cluster_columns = FALSE,
+    row_order = row_order,
+    column_order = col_order,
+    left_annotation = left_anno,
+    top_annotation = top_anno,
+    show_row_names = TRUE,
+    show_column_names = TRUE,
+    column_title = "Tested on",
+    row_title = "Trained on",
+    column_title_side = "bottom",
+    row_title_side = "right",
+    row_names_gp = grid::gpar(fontsize = 12),
+    column_names_gp = grid::gpar(fontsize = 12),
+    column_names_rot = 0,
+    rect_gp = grid::gpar(col = NA),
+    na_col = "grey95",
+    show_heatmap_legend = TRUE
+  )
+}
+
+# makeCrossDrugHeatmapPlotly: interactive plotly rendering of the same cross-drug
+# matrix for the dashboard panel (the static ComplexHeatmap above is reserved for
+# the export). Rows/columns stay grouped by class; hover shows the train/test
+# pair and median nMCC. Arguments match .buildCrossDrugMatrix(). Returns a plotly
+# object, or NULL when there are no cross-drug rows.
+makeCrossDrugHeatmapPlotly <- function(perf_data, meta = NULL, bug = NULL) {
+  prep <- .buildCrossDrugMatrix(perf_data, meta = meta, bug = bug)
+  if (is.null(prep)) {
+    return(NULL)
+  }
+  mat <- prep$mat
+
+  # Diverging RdBu colourscale (low nMCC red -> high blue), matching the export.
+  scale <- .crossDrugColorScale(mat)
+  if (is.null(scale)) {
+    return(NULL)
+  }
+  stops <- seq(0, 1, length.out = length(scale$colors))
+  colorscale <- Map(function(s, col) list(s, col), stops, scale$colors)
+
+  plotly::plot_ly(
+    x = colnames(mat),
+    y = rownames(mat),
+    z = mat,
+    type = "heatmap",
+    colorscale = colorscale,
+    zmin = scale$lo, zmax = scale$hi,
+    colorbar = list(title = "median\nnMCC"),
+    hovertemplate = paste0(
+      "<b>Trained on:</b> %{y}<br>",
+      "<b>Tested on:</b> %{x}<br>",
+      "<b>Median nMCC:</b> %{z:.3f}<extra></extra>"
+    )
+  ) |>
+    plotly::layout(
+      title = list(
+        text = "Cross-drug performance", x = 0, font = list(size = 13)
+      ),
+      xaxis = list(title = "Tested on", side = "bottom"),
+      yaxis = list(title = "Trained on", autorange = "reversed"),
+      margin = list(l = 80, b = 60, t = 50)
+    )
+}

--- a/R/plots_featureimportance.R
+++ b/R/plots_featureimportance.R
@@ -434,3 +434,80 @@ makeFeatureImportTable <- function(feature_import_table) {
     selection = "single"
   )
 }
+
+
+# makeTopFeatsVIPlot: horizontal bar of the top-N signed feature importances for
+# a single model selection (bug x drug x scale x encoding). Ported from
+# amRml::plotTopFeatsVI() and adapted to amRviz's top-features schema; rendered
+# with plotly for the dashboard. Unlike makeFeatureImportancePlot (a heatmap
+# across bugs/drugs), this shows per-feature effect direction via Sign.
+# data: top-features tibble from loadTopFeat() / topFeatures().
+# Returns a plotly object, or NULL when no features match the selection.
+makeTopFeatsVIPlot <- function(data, bug, amr_drug, model_scale, data_type_,
+                               top_n_features = 10) {
+  if (is.null(data) || !is.data.frame(data) || !nrow(data)) {
+    return(NULL)
+  }
+  if (!all(c(
+    "species", "drug_or_class", "feature_type", "feature_subtype",
+    "Variable", "Importance", "Sign", "strat_label"
+  ) %in% names(data))) {
+    return(NULL)
+  }
+
+  top_n <- suppressWarnings(as.numeric(top_n_features))
+  if (!is.finite(top_n) || top_n < 1) {
+    top_n <- 10
+  }
+
+  # Same baseline-model filter as makeFeatureImportancePlot.
+  df <- data |>
+    dplyr::mutate(species = normalize_species(.data$species)) |>
+    dplyr::filter(.data$species %in% normalize_species(bug)) |>
+    dplyr::filter(.data$drug_or_class %in% amr_drug) |>
+    dplyr::filter(.data$feature_type %in% c(model_scale, "struct")) |>
+    dplyr::filter(.data$feature_subtype %in% data_type_) |>
+    dplyr::filter(is.na(.data$strat_label) | !nzchar(.data$strat_label)) |>
+    dplyr::filter(!is.na(.data$Importance))
+  if (!nrow(df)) {
+    return(NULL)
+  }
+
+  # Collapse repeated rows (e.g. multiple seeds) to one value per feature:
+  # median importance, with the majority sign for the colour.
+  vip <- df |>
+    dplyr::group_by(.data$Variable) |>
+    dplyr::summarise(
+      Importance = stats::median(.data$Importance, na.rm = TRUE),
+      Sign = {
+        tb <- table(.data$Sign)
+        if (length(tb)) names(tb)[which.max(tb)] else NA_character_
+      },
+      .groups = "drop"
+    ) |>
+    dplyr::slice_max(order_by = .data$Importance, n = top_n, with_ties = FALSE) |>
+    dplyr::arrange(.data$Importance) |>
+    dplyr::mutate(
+      Variable = factor(.data$Variable, levels = .data$Variable),
+      Sign = factor(.data$Sign, levels = c("POS", "NEG"))
+    )
+
+  sign_colors <- c("POS" = "#c6d8d3", "NEG" = "#f6c9a1")
+  plotly::plot_ly(
+    vip,
+    x = ~Importance,
+    y = ~Variable,
+    color = ~Sign,
+    colors = sign_colors,
+    type = "bar",
+    orientation = "h",
+    hovertemplate = paste0(
+      "<b>%{y}</b><br>Importance: %{x:.3g}<extra></extra>"
+    )
+  ) |>
+    plotly::layout(
+      xaxis = list(title = "Importance"),
+      yaxis = list(title = "Features"),
+      legend = list(title = list(text = "Sign"))
+    )
+}

--- a/R/plots_modelperf.R
+++ b/R/plots_modelperf.R
@@ -474,3 +474,45 @@ makeNmccHeatmap <- function(data, selected_drug_class = NULL) {
       legend = list(orientation = "h", y = -0.15)
     )
 }
+
+
+# makeMDRPerformancePlot: nMCC distribution of multi-drug-resistance (MDR) models
+# by feature type, points coloured by encoding (binary/counts). Ported from the
+# performance panel of amRml::plotMDR() (the prediction-proportion tile needs an
+# MDR_pred file amRviz does not ship, so it is omitted) and adapted to nMCC.
+# mdr_perf: tibble from loadMDRResults().
+# Returns a plotly object, or NULL when there are no MDR rows.
+makeMDRPerformancePlot <- function(mdr_perf) {
+  if (is.null(mdr_perf) || !is.data.frame(mdr_perf) || !nrow(mdr_perf)) {
+    return(NULL)
+  }
+  if (!all(c("feature_type", "feature_subtype", "nmcc") %in% names(mdr_perf))) {
+    return(NULL)
+  }
+  df <- mdr_perf |> dplyr::filter(!is.na(.data$nmcc))
+  if (!nrow(df)) {
+    return(NULL)
+  }
+
+  subtype_colors <- c("binary" = "#7B9CB5", "counts" = "#CC8644")
+  plotly::plot_ly(
+    df,
+    x = ~feature_type,
+    y = ~nmcc,
+    color = ~feature_subtype,
+    colors = subtype_colors,
+    type = "box",
+    boxpoints = "all",
+    jitter = 0.3,
+    pointpos = 0,
+    hovertemplate = paste0(
+      "<b>%{x}</b><br>nMCC: %{y:.3f}<extra></extra>"
+    )
+  ) |>
+    plotly::layout(
+      boxmode = "group",
+      xaxis = list(title = "Feature type"),
+      yaxis = list(title = "nMCC", range = c(0, 1)),
+      legend = list(title = list(text = "Encoding"))
+    )
+}

--- a/R/plots_network.R
+++ b/R/plots_network.R
@@ -146,7 +146,7 @@ makeDrugFeatureNetwork <- function(top_data, bug, top_n = 10,
     .domain(["drug","variable","cluster","cog"])
     .range(["#d4872a","#5b8db8","#66a61e","#9b7fba"])'
 
-  networkD3::forceNetwork(
+  .styleNetwork(networkD3::forceNetwork(
     Links = edges,
     Nodes = nodes,
     Source = "source",
@@ -158,10 +158,11 @@ makeDrugFeatureNetwork <- function(top_data, bug, top_n = 10,
     opacity = 0.9,
     zoom = TRUE,
     fontSize = 13,
+    fontFamily = .NETWORK_FONT,
     linkDistance = 100,
     charge = -80,
     legend = TRUE
-  )
+  ))
 }
 
 
@@ -237,7 +238,7 @@ makeFeatureEgoNetwork <- function(enriched_tbl, variable) {
     .domain(["variable","cluster","cog"])
     .range(["#5b8db8","#66a61e","#9b7fba"])'
 
-  networkD3::forceNetwork(
+  .styleNetwork(networkD3::forceNetwork(
     Links = edges,
     Nodes = nodes,
     Source = "source",
@@ -249,8 +250,75 @@ makeFeatureEgoNetwork <- function(enriched_tbl, variable) {
     opacity = 0.9,
     zoom = TRUE,
     fontSize = 12,
+    fontFamily = .NETWORK_FONT,
     linkDistance = 80,
     charge = -120,
     legend = TRUE
-  )
+  ))
+}
+
+
+# Font family for the force-directed networks, matching the plotly/ggplot
+# panels (which use "Arial, sans-serif").
+.NETWORK_FONT <- "Arial, sans-serif"
+
+# Post-render hook for forceNetwork: replace each node's default circle with a
+# shape keyed to its node_type group so element types are distinguishable
+# beyond colour (drug = diamond, variable = circle, cluster = square,
+# cog = triangle). Wrapped in try/catch so the network falls back to circles
+# if the D3 internals change.
+.NETWORK_SHAPE_JS <- "
+function(el, x) {
+  try {
+    var d3 = window.d3;
+    if (!d3 || !d3.symbol) { return; }
+    var shapeMap = {
+      'drug': d3.symbolDiamond,
+      'variable': d3.symbolCircle,
+      'cluster': d3.symbolSquare,
+      'cog': d3.symbolTriangle
+    };
+    var sym = d3.symbol();
+    d3.select(el).selectAll('.node').each(function(d) {
+      var g = d3.select(this);
+      var circle = g.select('circle');
+      if (circle.empty()) { return; }
+      var fill = circle.style('fill');
+      var r = parseFloat(circle.attr('r')) || 8;
+      var type = shapeMap[d.group] || d3.symbolCircle;
+      circle.style('display', 'none');
+      g.insert('path', ':first-child')
+        .attr('class', 'node-shape')
+        .attr('d', sym.type(type).size(Math.PI * r * r * 1.6)())
+        .style('fill', fill)
+        .style('opacity', 0.9)
+        .style('stroke', '#ffffff')
+        .style('stroke-width', 1.2);
+    });
+    // Mirror the shapes in the legend: swap each colour rect for its glyph.
+    var legendSym = d3.symbol().size(150);
+    d3.select(el).selectAll('.legend').each(function(d) {
+      var g = d3.select(this);
+      var rect = g.select('rect');
+      if (rect.empty()) { return; }
+      var fill = rect.style('fill');
+      var type = shapeMap[d] || d3.symbolCircle;
+      rect.style('display', 'none');
+      g.insert('path', ':first-child')
+        .attr('class', 'legend-shape')
+        .attr('transform', 'translate(9,9)')
+        .attr('d', legendSym.type(type)())
+        .style('fill', fill)
+        .style('stroke', fill);
+    });
+  } catch (e) { /* keep default circles on error */ }
+}
+"
+
+# Apply the shared font + per-group node shapes to a forceNetwork widget.
+.styleNetwork <- function(net) {
+  if (is.null(net)) {
+    return(NULL)
+  }
+  htmlwidgets::onRender(net, .NETWORK_SHAPE_JS)
 }

--- a/R/queryDataUI.R
+++ b/R/queryDataUI.R
@@ -42,7 +42,7 @@ queryDataUI <- function() {
               downloadButton(
                 outputId = "query_data_download",
                 label = "Download Selected Data (CSV)",
-                class = "btn btn-success"
+                class = "btn btn-export"
               )
             )
           ),
@@ -84,7 +84,7 @@ queryDataUI <- function() {
               downloadButton(
                 outputId = "top_features_download",
                 label = "Download Selected Data (CSV)",
-                class = "btn btn-success"
+                class = "btn btn-export"
               )
             )
           ),

--- a/R/utils_data.R
+++ b/R/utils_data.R
@@ -163,3 +163,60 @@ get_metadata_path <- function(species_code, results_root = NULL) {
   }
   NULL
 }
+
+
+# Load the MDR (multi-drug-resistance) performance parquet from a species
+# directory. The baseline/cross loaders deliberately exclude *_MDR_ML_perf
+# files; this one keeps only them so MDR models can be surfaced separately.
+.load_one_species_mdr <- function(species_dir, verbose = TRUE) {
+  fps <- list.files(
+    species_dir,
+    pattern = "_MDR_ML_perf\\.parquet$", full.names = TRUE
+  )
+  if (!length(fps)) {
+    return(tibble::tibble())
+  }
+  df <- dplyr::bind_rows(lapply(fps, .read_parquet_safe, verbose = verbose))
+  if (nrow(df)) df$species_label <- basename(species_dir)
+  df
+}
+
+# Public loader for MDR performance, mirroring loadMLResults().
+loadMDRResults <- function(results_root = NULL, species_dirs = NULL,
+                           verbose = TRUE) {
+  rr <- .normalize_results_root(results_root)
+
+  if (!is.null(rr) && !is.null(species_dirs) && length(species_dirs) > 0) {
+    dfs <- lapply(species_dirs, .load_one_species_mdr, verbose = verbose)
+    return(dplyr::bind_rows(dfs))
+  }
+
+  if (!is.null(rr) && is.null(species_dirs)) {
+    return(tibble::tibble())
+  }
+
+  # Demo fallback: scan extdata subdirectories for *_MDR_ML_perf.parquet
+  extdata <- system.file("extdata", package = "amRviz")
+  if (!nzchar(extdata)) {
+    return(tibble::tibble())
+  }
+  subdirs <- list.dirs(extdata, full.names = TRUE, recursive = FALSE)
+  if (isTRUE(verbose)) message("loadMDRResults(): using packaged demo parquets")
+  dplyr::bind_rows(lapply(subdirs, .load_one_species_mdr, verbose = verbose))
+}
+
+
+# Load the drug -> class abbreviation map for a species from its metadata
+# parquet. Returns a tibble with distinct drug_abbr / class_abbr rows used to
+# annotate the cross-drug heatmap, or NULL if no metadata is found.
+load_drug_class_map <- function(species_code, results_root = NULL) {
+  fp <- get_metadata_path(species_code, results_root = results_root)
+  if (is.null(fp) || !file.exists(fp)) {
+    return(NULL)
+  }
+  md <- tryCatch(arrow::read_parquet(fp), error = function(e) NULL)
+  if (is.null(md) || !all(c("drug_abbr", "class_abbr") %in% names(md))) {
+    return(NULL)
+  }
+  dplyr::distinct(md, .data$drug_abbr, .data$class_abbr)
+}

--- a/R/utils_export.R
+++ b/R/utils_export.R
@@ -1,0 +1,152 @@
+# Heatmap / widget export helpers (PDF + static PNG).
+
+
+# .plotlyHeatmapMatrix: pull the z matrix (with x/y as column/row names) out of a
+# plotly heatmap object built by any of the dashboard's plot_ly(type="heatmap")
+# renderers. Returns a labelled numeric matrix, or NULL if the object is not a
+# heatmap. This lets a single ComplexHeatmap exporter serve every heatmap panel
+# without re-deriving each one's matrix.
+.plotlyHeatmapMatrix <- function(p) {
+  if (is.null(p) || !inherits(p, c("plotly", "htmlwidget"))) {
+    return(NULL)
+  }
+  b <- tryCatch(plotly::plotly_build(p), error = function(e) NULL)
+  if (is.null(b) || is.null(b$x$data)) {
+    return(NULL)
+  }
+  traces <- b$x$data
+  idx <- which(vapply(
+    traces, function(t) identical(t$type, "heatmap"), logical(1)
+  ))
+  if (!length(idx)) {
+    return(NULL)
+  }
+  d <- traces[[idx[1]]]
+  if (is.null(d$z)) {
+    return(NULL)
+  }
+  mat <- suppressWarnings(as.matrix(d$z))
+  if (!is.numeric(mat) || !length(mat)) {
+    return(NULL)
+  }
+  rows <- unlist(d$y)
+  cols <- unlist(d$x)
+  if (length(rows) == nrow(mat)) rownames(mat) <- rows
+  if (length(cols) == ncol(mat)) colnames(mat) <- cols
+  mat
+}
+
+# makeHeatmapExport: convert any dashboard heatmap (a plotly object) into a static
+# ComplexHeatmap::Heatmap for publication-quality PDF export. Colours use an RdBu
+# diverging ramp mapped to the data range. Returns a Heatmap object, or NULL when
+# the input is not a heatmap or has no finite values.
+makeHeatmapExport <- function(p, name = "value",
+                              column_title = NULL, row_title = NULL) {
+  mat <- .plotlyHeatmapMatrix(p)
+  if (is.null(mat)) {
+    return(NULL)
+  }
+  finite_vals <- mat[is.finite(mat)]
+  if (!length(finite_vals)) {
+    return(NULL)
+  }
+  rng <- range(finite_vals)
+  if (rng[1] == rng[2]) {
+    rng <- rng + c(-0.5, 0.5)
+  }
+  heat_colors <- grDevices::colorRampPalette(
+    RColorBrewer::brewer.pal(11, "RdBu")
+  )(100)
+  col_fun <- circlize::colorRamp2(
+    seq(rng[1], rng[2], length.out = length(heat_colors)),
+    heat_colors
+  )
+
+  tryCatch(
+    ComplexHeatmap::Heatmap(
+      mat,
+      name = name,
+      col = col_fun,
+      cluster_rows = FALSE,
+      cluster_columns = FALSE,
+      column_title = column_title,
+      row_title = row_title,
+      na_col = "grey95",
+      rect_gp = grid::gpar(col = NA),
+      row_names_gp = grid::gpar(fontsize = 8),
+      column_names_gp = grid::gpar(fontsize = 10),
+      show_heatmap_legend = TRUE
+    ),
+    error = function(e) NULL
+  )
+}
+
+# .writeHeatmapPdf: render a ComplexHeatmap object to a PDF file for a Shiny
+# downloadHandler, or a placeholder message when there is nothing to draw.
+.writeHeatmapPdf <- function(file, hm, width = 9, height = 7,
+                             empty_msg = "No data available for this selection.") {
+  grDevices::pdf(file, width = width, height = height)
+  on.exit(grDevices::dev.off())
+  drawn <- if (!is.null(hm)) {
+    isTRUE(tryCatch(
+      {
+        ComplexHeatmap::draw(hm)
+        TRUE
+      },
+      error = function(e) FALSE
+    ))
+  } else {
+    FALSE
+  }
+  if (!drawn) {
+    grid::grid.newpage()
+    grid::grid.text(empty_msg, gp = grid::gpar(fontsize = 12, col = "grey40"))
+  }
+}
+
+# .exportBtn: small right-aligned "Export (PDF)" button for an interactive
+# panel, paired with the server's "<id>_static_download" downloadHandler.
+.exportBtn <- function(id) {
+  shiny::div(
+    style = "text-align: right; padding: 2px 6px;",
+    shiny::downloadButton(
+      paste0(id, "_static_download"), "Export (PDF)",
+      class = "btn btn-export"
+    )
+  )
+}
+
+# .writeWidgetStatic: render any interactive htmlwidget (plotly, networkD3
+# force/sankey) to a static PDF for a download handler, via a headless-browser
+# snapshot (webshot2 + chromote). Used for the dashboard panels that are not
+# plain heatmaps (which use the vector ComplexHeatmap path instead). Falls back
+# to a placeholder PDF when the widget is NULL or the browser tooling/Chrome is
+# unavailable, so a download never hard-errors.
+.writeWidgetStatic <- function(file, widget, vwidth = 1000, vheight = 700,
+                               empty_msg = "No data available for this selection.") {
+  ok <- !is.null(widget) &&
+    requireNamespace("htmlwidgets", quietly = TRUE) &&
+    requireNamespace("webshot2", quietly = TRUE)
+  if (ok) {
+    ok <- tryCatch(
+      {
+        html <- tempfile(fileext = ".html")
+        out <- tempfile(fileext = ".pdf")
+        on.exit(unlink(c(html, out)), add = TRUE)
+        htmlwidgets::saveWidget(widget, html, selfcontained = TRUE)
+        webshot2::webshot(
+          html, out,
+          delay = 0.8, vwidth = vwidth, vheight = vheight
+        )
+        file.copy(out, file, overwrite = TRUE)
+      },
+      error = function(e) FALSE
+    )
+  }
+  if (!isTRUE(ok)) {
+    grDevices::pdf(file)
+    on.exit(grDevices::dev.off(), add = TRUE)
+    grid::grid.newpage()
+    grid::grid.text(empty_msg, gp = grid::gpar(fontsize = 12, col = "grey40"))
+  }
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -198,7 +198,7 @@ https://github.com/JRaviLab/amR
 
 This package is being prepared for Bioconductor submission. It includes:
 
-- **biocViews**: AMR, GUI, MicrobialGenomics, Pathogen, Visualization
+- **biocViews**: Software, FunctionalGenomics, Genetics, GUI, Visualization
 - **R version requirement**: R >= 4.5.0
 - **Documentation**: Function documentation with examples, plus a usage vignette
 - **Data**: Pre-computed amRml results for *Shigella flexneri* included in `inst/extdata/`

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If you use `amRviz` in your research, please cite:
 
 This package is being prepared for Bioconductor submission. It includes:
 
--   **biocViews**: AMR, GUI, MicrobialGenomics, Pathogen, Visualization
+-   **biocViews**: Software, FunctionalGenomics, Genetics, GUI, Visualization
 -   **R version requirement**: R &gt;= 4.5.0
 -   **Documentation**: Function documentation with examples, plus a
     usage vignette

--- a/tests/testthat/test-crossDrugHeatmap.R
+++ b/tests/testthat/test-crossDrugHeatmap.R
@@ -1,0 +1,138 @@
+## Tests for the cross-drug generalization heatmap functions
+## (.buildCrossDrugMatrix, makeCrossDrugHeatmap, makeCrossDrugHeatmapPlotly)
+
+# Minimal synthetic performance tibble with the columns the cross-drug
+# functions require: cross rows (cross_test == TRUE, ref_drug/test_drug set)
+# plus baseline diagonal rows (cross_test == FALSE, strat_label NA).
+make_cross_perf <- function() {
+  # Off-diagonal cross-testing only (a drug is not cross-tested against itself);
+  # the matrix diagonal is supplied by the baseline rows below.
+  cross <- tibble::tibble(
+    cross_test = TRUE,
+    drug_label = "drug",
+    strat_label = NA_character_,
+    ref_drug = c("AMP", "TET"),
+    test_drug = c("TET", "AMP"),
+    drug_or_class = c("AMP", "TET"),
+    nmcc = c(0.40, 0.30),
+    species = "cross"
+  )
+  diag <- tibble::tibble(
+    cross_test = FALSE,
+    drug_label = "drug",
+    strat_label = NA_character_,
+    ref_drug = NA_character_,
+    test_drug = NA_character_,
+    drug_or_class = c("AMP", "TET"),
+    nmcc = c(0.95, 0.85),
+    species = "Escherichia_coli"
+  )
+  dplyr::bind_rows(cross, diag)
+}
+
+make_cross_meta <- function() {
+  tibble::tibble(
+    drug_abbr = c("AMP", "TET"),
+    class_abbr = c("Penicillins", "Tetracyclines")
+  )
+}
+
+# ── .buildCrossDrugMatrix ────────────────────────────────────────────────────
+
+test_that(".buildCrossDrugMatrix returns an ordered square matrix", {
+  prep <- .buildCrossDrugMatrix(make_cross_perf(), meta = make_cross_meta())
+
+  expect_type(prep, "list")
+  expect_true(is.matrix(prep$mat))
+  expect_equal(dim(prep$mat), c(2L, 2L))
+  expect_setequal(rownames(prep$mat), c("AMP", "TET"))
+  expect_setequal(colnames(prep$mat), c("AMP", "TET"))
+  # Diagonal comes from the baseline self-evaluation rows.
+  expect_equal(prep$mat["AMP", "AMP"], 0.95)
+  expect_equal(prep$mat["TET", "TET"], 0.85)
+  # Class lookup is populated from the metadata.
+  expect_equal(unname(prep$class_of["AMP"]), "Penicillins")
+})
+
+test_that(".buildCrossDrugMatrix works without metadata", {
+  prep <- .buildCrossDrugMatrix(make_cross_perf(), meta = NULL)
+
+  expect_true(is.matrix(prep$mat))
+  expect_true(all(is.na(prep$class_of)))
+})
+
+test_that(".buildCrossDrugMatrix returns NULL for empty or invalid input", {
+  expect_null(.buildCrossDrugMatrix(NULL))
+  expect_null(.buildCrossDrugMatrix(data.frame()))
+  # Missing the required cross-drug columns.
+  expect_null(.buildCrossDrugMatrix(tibble::tibble(a = 1, b = 2)))
+})
+
+test_that(".buildCrossDrugMatrix returns NULL with no cross-drug rows", {
+  baseline_only <- make_cross_perf() |>
+    dplyr::filter(.data$cross_test %in% FALSE)
+  expect_null(.buildCrossDrugMatrix(baseline_only))
+})
+
+# ── makeCrossDrugHeatmap (ComplexHeatmap, static export) ─────────────────────
+
+test_that("makeCrossDrugHeatmap returns a ComplexHeatmap Heatmap object", {
+  hm <- makeCrossDrugHeatmap(make_cross_perf(), meta = make_cross_meta())
+  expect_s4_class(hm, "Heatmap")
+})
+
+test_that("makeCrossDrugHeatmap returns NULL for empty input", {
+  expect_null(makeCrossDrugHeatmap(NULL))
+  expect_null(makeCrossDrugHeatmap(data.frame()))
+})
+
+test_that("makeCrossDrugHeatmap renders to a non-empty PDF", {
+  hm <- makeCrossDrugHeatmap(make_cross_perf(), meta = make_cross_meta())
+  tmp <- tempfile(fileext = ".pdf")
+  grDevices::pdf(tmp)
+  ComplexHeatmap::draw(hm)
+  grDevices::dev.off()
+  expect_gt(file.info(tmp)$size, 0)
+})
+
+# ── makeCrossDrugHeatmapPlotly (interactive dashboard panel) ─────────────────
+
+test_that("makeCrossDrugHeatmapPlotly returns a plotly object", {
+  result <- makeCrossDrugHeatmapPlotly(
+    make_cross_perf(),
+    meta = make_cross_meta()
+  )
+  expect_s3_class(result, "plotly")
+})
+
+test_that("makeCrossDrugHeatmapPlotly returns NULL for empty input", {
+  expect_null(makeCrossDrugHeatmapPlotly(NULL))
+  expect_null(makeCrossDrugHeatmapPlotly(data.frame()))
+})
+
+# ── End-to-end with bundled demo data ────────────────────────────────────────
+
+test_that("makeCrossDrugHeatmap renders from bundled Shigella demo data", {
+  fp <- system.file(
+    "extdata", "Shigella_flexneri", "Sfl_cross_ML_perf.parquet",
+    package = "amRviz"
+  )
+  skip_if(!nzchar(fp) || !file.exists(fp), "No bundled cross-drug demo data")
+
+  perf <- arrow::read_parquet(fp)
+  mfp <- system.file(
+    "extdata", "Shigella_flexneri", "Sfl_metadata.parquet",
+    package = "amRviz"
+  )
+  meta <- if (nzchar(mfp) && file.exists(mfp)) {
+    arrow::read_parquet(mfp)
+  } else {
+    NULL
+  }
+
+  hm <- makeCrossDrugHeatmap(perf, meta = meta)
+  expect_s4_class(hm, "Heatmap")
+
+  ply <- makeCrossDrugHeatmapPlotly(perf, meta = meta)
+  expect_s3_class(ply, "plotly")
+})

--- a/tests/testthat/test-heatmapExport.R
+++ b/tests/testthat/test-heatmapExport.R
@@ -1,0 +1,77 @@
+## Tests for the generic heatmap PDF export helpers:
+## .plotlyHeatmapMatrix, makeHeatmapExport, .writeHeatmapPdf
+
+make_heatmap_plotly <- function() {
+  m <- matrix(
+    c(0.1, 0.9, 0.5, 0.3),
+    nrow = 2,
+    dimnames = list(c("r1", "r2"), c("c1", "c2"))
+  )
+  plotly::plot_ly(x = colnames(m), y = rownames(m), z = m, type = "heatmap")
+}
+
+make_bar_plotly <- function() {
+  plotly::plot_ly(x = c("a", "b"), y = c(1, 2), type = "bar")
+}
+
+# ── .plotlyHeatmapMatrix ─────────────────────────────────────────────────────
+
+test_that(".plotlyHeatmapMatrix extracts a labelled matrix from a heatmap", {
+  mat <- .plotlyHeatmapMatrix(make_heatmap_plotly())
+  expect_true(is.matrix(mat))
+  expect_equal(dim(mat), c(2L, 2L))
+  expect_setequal(rownames(mat), c("r1", "r2"))
+  expect_setequal(colnames(mat), c("c1", "c2"))
+})
+
+test_that(".plotlyHeatmapMatrix returns NULL for non-heatmap / NULL input", {
+  expect_null(.plotlyHeatmapMatrix(make_bar_plotly()))
+  expect_null(.plotlyHeatmapMatrix(NULL))
+})
+
+# ── makeHeatmapExport ────────────────────────────────────────────────────────
+
+test_that("makeHeatmapExport returns a ComplexHeatmap from a heatmap plotly", {
+  hm <- makeHeatmapExport(make_heatmap_plotly(), name = "v")
+  expect_s4_class(hm, "Heatmap")
+})
+
+test_that("makeHeatmapExport returns NULL for non-heatmap / NULL input", {
+  expect_null(makeHeatmapExport(make_bar_plotly()))
+  expect_null(makeHeatmapExport(NULL))
+})
+
+# ── .writeHeatmapPdf ─────────────────────────────────────────────────────────
+
+test_that(".writeHeatmapPdf renders a non-empty PDF for a heatmap", {
+  hm <- makeHeatmapExport(make_heatmap_plotly())
+  tmp <- tempfile(fileext = ".pdf")
+  .writeHeatmapPdf(tmp, hm)
+  expect_gt(file.info(tmp)$size, 0)
+})
+
+test_that(".writeHeatmapPdf renders a placeholder PDF when hm is NULL", {
+  tmp <- tempfile(fileext = ".pdf")
+  .writeHeatmapPdf(tmp, NULL)
+  expect_gt(file.info(tmp)$size, 0)
+})
+
+# ── End-to-end: dashboard heatmaps export to ComplexHeatmap ──────────────────
+
+test_that("dashboard heatmaps convert to ComplexHeatmap exports", {
+  tf <- loadTopFeat(verbose = FALSE)
+  perf <- loadMLResults(verbose = FALSE)
+  skip_if(nrow(tf) == 0 || nrow(perf) == 0, "No demo data")
+
+  drugs <- unique(tf$drug_or_class[!is.na(tf$drug_or_class)])
+
+  fi <- makeFeatureImportancePlot(
+    tf, "Sfl", drugs[seq_len(min(3, length(drugs)))],
+    "genes", "binary", 10, "across_drug"
+  )
+  expect_s4_class(makeHeatmapExport(fi, name = "Importance"), "Heatmap")
+
+  perf_hm <- makeCrossModelPerformancePlot(perf, "Sfl", drugs[1], "country")
+  skip_if(is.null(perf_hm), "No cross-model performance demo data")
+  expect_s4_class(makeHeatmapExport(perf_hm, name = "nMCC"), "Heatmap")
+})

--- a/tests/testthat/test-network.R
+++ b/tests/testthat/test-network.R
@@ -26,6 +26,26 @@ test_that("makeDrugFeatureNetwork returns a forceNetwork for demo data", {
   expect_s3_class(result, "htmlwidget")
 })
 
+test_that("network visualisations carry the shared font + node-shape hook", {
+  skip_if_not_installed("networkD3")
+
+  top_data <- suppressMessages(loadTopFeat(verbose = FALSE))
+  skip_if(nrow(top_data) == 0, "No demo top-features data")
+
+  net <- makeDrugFeatureNetwork(
+    top_data,
+    bug = unique(top_data$species)[1], top_n = 5
+  )
+  # Font matches the plotly/ggplot panels.
+  expect_equal(net$x$options$fontFamily, "Arial, sans-serif")
+  # Per-group node shapes are applied via an onRender hook.
+  expect_false(is.null(net$jsHooks$render))
+  expect_match(net$jsHooks$render[[1]]$code, "d3.symbol")
+  # Shapes are mirrored in both the nodes and the legend.
+  expect_match(net$jsHooks$render[[1]]$code, "node-shape")
+  expect_match(net$jsHooks$render[[1]]$code, "legend-shape")
+})
+
 # ── makeFeatureEgoNetwork ───────────────────────────────────────────────────
 
 test_that("makeFeatureEgoNetwork returns NULL for NULL input", {

--- a/tests/testthat/test-portedPlots.R
+++ b/tests/testthat/test-portedPlots.R
@@ -1,0 +1,108 @@
+## Tests for plots ported from amRml PR #8:
+## makeTopFeatsVIPlot, makeMDRPerformancePlot, and the loadMDRResults loader.
+
+# ── makeTopFeatsVIPlot ───────────────────────────────────────────────────────
+
+make_topfeat <- function() {
+  tibble::tibble(
+    species = "Sfl",
+    drug_or_class = "AMP",
+    feature_type = "genes",
+    feature_subtype = "binary",
+    strat_label = NA_character_,
+    Variable = c("geneA", "geneB", "geneC", "geneD"),
+    Importance = c(0.9, 0.7, 0.5, 0.3),
+    Sign = c("POS", "NEG", "POS", "NEG")
+  )
+}
+
+test_that("makeTopFeatsVIPlot returns a plotly object for a valid selection", {
+  result <- makeTopFeatsVIPlot(
+    make_topfeat(),
+    bug = "Sfl", amr_drug = "AMP",
+    model_scale = "genes", data_type_ = "binary",
+    top_n_features = 3
+  )
+  expect_s3_class(result, "plotly")
+})
+
+test_that("makeTopFeatsVIPlot returns NULL when nothing matches the filter", {
+  expect_null(makeTopFeatsVIPlot(
+    make_topfeat(),
+    bug = "Zzz", amr_drug = "nope",
+    model_scale = "genes", data_type_ = "binary"
+  ))
+})
+
+test_that("makeTopFeatsVIPlot handles a group with all-NA Sign without error", {
+  df <- make_topfeat()
+  df$Sign <- NA_character_
+  result <- makeTopFeatsVIPlot(
+    df,
+    bug = "Sfl", amr_drug = "AMP",
+    model_scale = "genes", data_type_ = "binary"
+  )
+  expect_s3_class(result, "plotly")
+})
+
+test_that("makeTopFeatsVIPlot returns NULL for empty or invalid input", {
+  expect_null(makeTopFeatsVIPlot(
+    NULL, "Sfl", "AMP", "genes", "binary"
+  ))
+  expect_null(makeTopFeatsVIPlot(
+    tibble::tibble(a = 1), "Sfl", "AMP", "genes", "binary"
+  ))
+})
+
+# ── makeMDRPerformancePlot ───────────────────────────────────────────────────
+
+make_mdr <- function() {
+  tibble::tibble(
+    feature_type = c("genes", "genes", "domains", "domains"),
+    feature_subtype = c("binary", "counts", "binary", "counts"),
+    nmcc = c(0.8, 0.6, 0.7, 0.5)
+  )
+}
+
+test_that("makeMDRPerformancePlot returns a plotly object", {
+  expect_s3_class(makeMDRPerformancePlot(make_mdr()), "plotly")
+})
+
+test_that("makeMDRPerformancePlot returns NULL for empty or invalid input", {
+  expect_null(makeMDRPerformancePlot(NULL))
+  expect_null(makeMDRPerformancePlot(data.frame()))
+  expect_null(makeMDRPerformancePlot(tibble::tibble(a = 1)))
+})
+
+test_that("makeMDRPerformancePlot returns NULL when all nmcc are NA", {
+  df <- make_mdr()
+  df$nmcc <- NA_real_
+  expect_null(makeMDRPerformancePlot(df))
+})
+
+# ── loadMDRResults + end-to-end with bundled demo data ───────────────────────
+
+test_that("loadMDRResults loads bundled MDR demo data", {
+  mdr <- loadMDRResults(verbose = FALSE)
+  skip_if(nrow(mdr) == 0, "No bundled MDR demo data")
+  expect_true("nmcc" %in% names(mdr))
+  expect_true("feature_type" %in% names(mdr))
+  expect_s3_class(makeMDRPerformancePlot(mdr), "plotly")
+})
+
+test_that("makeTopFeatsVIPlot renders from bundled demo top features", {
+  tf <- loadTopFeat(verbose = FALSE)
+  skip_if(nrow(tf) == 0, "No bundled top-feature demo data")
+
+  bug <- normalize_species(unique(tf$species))[1]
+  drug <- tf$drug_or_class[!is.na(tf$drug_or_class)][1]
+  result <- makeTopFeatsVIPlot(
+    tf,
+    bug = bug, amr_drug = drug,
+    model_scale = "genes", data_type_ = "binary",
+    top_n_features = 10
+  )
+  # Either a plotly object (matches found) or NULL (no genes/binary rows for
+  # this drug) — both are valid; assert it does not error.
+  expect_true(is.null(result) || inherits(result, "plotly"))
+})

--- a/tests/testthat/test-widgetExport.R
+++ b/tests/testthat/test-widgetExport.R
@@ -1,0 +1,34 @@
+## Tests for the static (PDF) export of interactive widgets:
+## .writeWidgetStatic and the .exportBtn UI helper.
+
+# ── .exportBtn ───────────────────────────────────────────────────────────────
+
+test_that(".exportBtn builds a download button with the paired id", {
+  btn <- .exportBtn("model_perfomance_plot")
+  html <- as.character(btn)
+  expect_match(html, "model_perfomance_plot_static_download")
+  expect_match(html, "Export \\(PDF\\)")
+  expect_match(html, "btn-export")
+})
+
+# ── .writeWidgetStatic ───────────────────────────────────────────────────────
+
+test_that(".writeWidgetStatic writes a placeholder PDF for a NULL widget", {
+  tmp <- tempfile(fileext = ".pdf")
+  .writeWidgetStatic(tmp, NULL)
+  expect_gt(file.info(tmp)$size, 0)
+})
+
+test_that(".writeWidgetStatic snapshots a plotly widget to a non-empty PDF", {
+  skip_if_not_installed("webshot2")
+  skip_if_not_installed("chromote")
+  skip_if(
+    !nzchar(tryCatch(chromote::find_chrome(), error = function(e) "")),
+    "No headless Chrome available"
+  )
+
+  p <- plotly::plot_ly(x = c("a", "b"), y = c(1, 2), type = "bar")
+  tmp <- tempfile(fileext = ".pdf")
+  .writeWidgetStatic(tmp, p)
+  expect_gt(file.info(tmp)$size, 0)
+})


### PR DESCRIPTION
### Summary
This PR adds the cross-drug generalization heatmap, adds several plots from amRml, gives every dashboard panel a dedicated export button, and restyles the interaction networks to have shapes rather than only colors for the legend. 
It also resolves the outstanding `BiocCheck` warning **"No Bioconductor dependencies detected"** since amRviz now depends on ComplexHeatmap (used for the static heatmap exports).

### Exports
- Heatmap panels export to publication-quality **ComplexHeatmap PDFs**.
- All other panels (plots, networks, Sankey) export to **static PDF** via a headless snapshot.
- 18 "Export (PDF)" buttons added across all tabs.

### Ported from amRml (PR #8)
- **Signed feature-importance bar** on the Feature Importance tab.
- **MDR model performance** in a new "MDR models" tab.

### Networks
- Node **shapes** per element type (drug, feature, cluster, COG), mirrored in the legend.
- Fonts now match the rest of the dashboard.
- Added a hint prompting users to select a table row to generate the ego network.

### Styling
- Unified small blue export/download buttons matching the navbar accent.

### Dependencies
- `Imports`: ComplexHeatmap, circlize, RColorBrewer, grid, grDevices, htmlwidgets.
- `Suggests`: webshot2 (chromote already present).
- `biocViews` updated to valid software terms; READMEs synced.

### Testing
- New tests for the heatmap, ported, and widget exports.
- ## Testing
Added 5 test files covering the new functionality:
- `test-crossDrugHeatmap.R` - cross-drug matrix prep, ComplexHeatmap object, plotly panel, PDF render
- `test-portedPlots.R` -`makeTopFeatsVIPlot`, `makeMDRPerformancePlot`, `loadMDRResults`
- `test-heatmapExport.R` -`makeHeatmapExport` / `.plotlyHeatmapMatrix` / `.writeHeatmapPdf`
- `test-widgetExport.R` - `.writeWidgetStatic` (incl. a real headless-Chrome snapshot) + `.exportBtn`
- `test-network.R` - added assertions for the node-shape/legend hook and shared font
- Full unit suite: **208 pass, 0 fail**.