### PR TITLE
Add McKim to authors; fix URL casing and update citation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,9 @@ Authors@R: c(
     person("Abhirupa", "Ghosh", , "abhirupa.ghosh@cuanschutz.edu", role = "ctb"),
     person("David", "Mayer", , "david.mayer@cuanschutz.edu", role = "ctb"),
     person("Evan", "Brenner", , "evan.brenner@cuanschutz.edu", role = "ctb"),
-    person("Charmie", "Vang", , "charmie.vang@cuanschutz.edu", role = "ctb")
+    person("Charmie", "Vang", , "charmie.vang@cuanschutz.edu", role = "ctb"),
+    person("Alexander", "McKim", , "alexander.mckim@cuanschutz.edu", role = "ctb",
+           comment = c(ORCID = "0000-0002-7802-7591"))
   )
 Description: Interactive Shiny dashboard for exploring antimicrobial resistance
     (AMR) data and machine learning model results from the AMR package suite.
@@ -58,6 +60,6 @@ biocViews:
     FunctionalGenomics,
     Genetics,
     Visualization
-URL: https://github.com/jravilab/amRviz
-BugReports: https://github.com/jravilab/amRviz/issues
+URL: https://github.com/JRaviLab/amRviz
+BugReports: https://github.com/JRaviLab/amRviz/issues
 Config/roxygen2/version: 8.0.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -187,12 +187,13 @@ amRviz/
 
 If you use `amRviz` in your research, please cite:
 
-```
-Brenner E, Ghosh A, Boyer E, Vang C, Wolfe E, McKim A, Lesiyon R, Mayer D, Ravi J. (2026).
-amR: an R package suite to predict antimicrobial resistance in bacterial pathogens.
-R package version 0.99.0.
-https://github.com/JRaviLab/amR
-```
+> Ghosh A^, Brenner EP^, Boyer EA, McKim AP, Vang CK, Wolfe EP, Mayer D, Lesiyon RL, Ravi J.
+>
+> amR: an R package suite to predict antimicrobial resistance in bacterial pathogens.
+>
+> bioRxiv. 2026. DOI: [10.64898/2026.07.10.734579](https://doi.org/10.64898/2026.07.10.734579).
+
+^ Co-first authors
 
 ## For Bioconductor submission
 

--- a/README.md
+++ b/README.md
@@ -197,10 +197,14 @@ organized into per-species subdirectories:
 
 If you use `amRviz` in your research, please cite:
 
-    Brenner E, Ghosh A, Boyer E, Vang C, Wolfe E, McKim A, Lesiyon R, Mayer D, Ravi J. (2026).
-    amR: an R package suite to predict antimicrobial resistance in bacterial pathogens.
-    R package version 0.99.0.
-    https://github.com/JRaviLab/amR
+> Ghosh A^, Brenner EP^, Boyer EA, McKim AP, Vang CK, Wolfe EP, Mayer D, Lesiyon RL, Ravi J.
+>
+> amR: an R package suite to predict antimicrobial resistance in bacterial pathogens.
+>
+> bioRxiv. 2026. DOI:
+> [10.64898/2026.07.10.734579](https://doi.org/10.64898/2026.07.10.734579).
+
+^ Co-first authors
 
 ## For Bioconductor submission
 


### PR DESCRIPTION
## Summary
Metadata and README cleanup for `amRviz` ahead of the bioRxiv preprint and Bioconductor submission. Documentation only — no functional code changes.

## Changes
- `DESCRIPTION`: add Alexander McKim as `ctb` with ORCID `0000-0002-7802-7591`
- `DESCRIPTION`: fix `URL`/`BugReports` casing — `github.com/jravilab` -> `github.com/JRaviLab`
- README: replace the plain-text citation block with the formatted bioRxiv citation (DOI [10.64898/2026.07.10.734579](https://doi.org/10.64898/2026.07.10.734579)), marking Ghosh & Brenner as co-first authors

## Review notes
- Please confirm the author list, name spellings, and ORCID are correct.
- `README.md` is regenerated from `README.Rmd`; both are included.
