### PR TITLE
Fix stale comment: susceptible color is blue, not grey

### DIFF
--- a/R/utils_colors.R
+++ b/R/utils_colors.R
@@ -19,7 +19,7 @@ SCALE_COLORS <- c(
 )
 # AMR phenotype palette (R/S/I plus full-word + lowercase variants so it works
 # regardless of how the column is encoded). Susceptible is intentionally
-# neutral grey so Resistant amber stands out as the signal of interest.
+# a muted blue so Resistant amber stands out as the signal of interest.
 PHENOTYPE_COLORS <- c(
   R = "#d4872a", Resistant = "#d4872a", resistant = "#d4872a",
   S = "#5b8db8", Susceptible = "#5b8db8", susceptible = "#5b8db8",


### PR DESCRIPTION
Comment said "neutral grey" but the value (#5b8db8) is blue, leftover from the grey→blue change made to sync with phenotype color changes implemented in [amRdata#33](https://github.com/JRaviLab/amRdata/pull/33). No functional change, comment only.
