### PR TITLE
Fix dashboard issues from #40

### DIFF
--- a/R/modelPerfUI.R
+++ b/R/modelPerfUI.R
@@ -41,7 +41,7 @@ modelPerfUI <- function() {
             fluidPage(
               tags$p(
                 style = "color: #555; font-size: 10px; padding-top: 10px;",
-                "Baseline models only (non-stratified, non-cross-test). ",
+                "Only baseline models from all the available species. ",
                 "Left: MCC distribution per species and molecular scale. ",
                 "Right: median MCC by drug class across species, ",
                 "molecular scale, and data encoding."
@@ -60,6 +60,10 @@ modelPerfUI <- function() {
           ),
           tabPanel(
             "Model performance",
+             fluidPage(
+              tags$p(
+                style = "color: #555; font-size: 10px; padding-top: 10px;","The filter options above allow to select a subset of species, drug classes, and drugs. ",
+                "The filter options below allow to select the model scale and data type")),
             tagList(
               fluidRow(
                 column(

--- a/R/modelPerfUI.R
+++ b/R/modelPerfUI.R
@@ -37,6 +37,28 @@ modelPerfUI <- function() {
         style = "padding: 0;",
         tabsetPanel(
           tabPanel(
+            "Performance overview",
+            fluidPage(
+              tags$p(
+                style = "color: #555; font-size: 10px; padding-top: 10px;",
+                "Baseline models only (non-stratified, non-cross-test). ",
+                "Left: MCC distribution per species and molecular scale. ",
+                "Right: median MCC by drug class across species, ",
+                "molecular scale, and data encoding."
+              ),
+              fluidRow(
+                column(4, plotly::plotlyOutput(
+                  "mcc_strip_plot",
+                  height = "420px"
+                )),
+                column(8, plotly::plotlyOutput(
+                  "mcc_heatmap",
+                  height = "420px"
+                ))
+              )
+            )
+          ),
+          tabPanel(
             "Model performance",
             tagList(
               fluidRow(
@@ -85,28 +107,6 @@ modelPerfUI <- function() {
                   style = "height: 600px;",
                   plotly::plotlyOutput("model_perfomance_plot", height = "100%")
                 )
-              )
-            )
-          ),
-          tabPanel(
-            "Performance overview",
-            fluidPage(
-              tags$p(
-                style = "color: #555; font-size: 10px; padding-top: 10px;",
-                "Baseline models only (non-stratified, non-cross-test). ",
-                "Left: MCC distribution per species and molecular scale. ",
-                "Right: median MCC by drug class across species, ",
-                "molecular scale, and data encoding."
-              ),
-              fluidRow(
-                column(4, plotly::plotlyOutput(
-                  "mcc_strip_plot",
-                  height = "420px"
-                )),
-                column(8, plotly::plotlyOutput(
-                  "mcc_heatmap",
-                  height = "420px"
-                ))
               )
             )
           )

--- a/R/plots_metadata.R
+++ b/R/plots_metadata.R
@@ -85,7 +85,7 @@ makeQuickStats <- function(data) {
     dplyr::pull(drug_class)
 
   top_n_countries <- data_with_drug_class |>
-    dplyr::filter(!grepl(pattern = "NA", x = genome.isolation_country)) |>
+    dplyr::filter(!is.na(genome.isolation_country)) |>
     dplyr::group_by(genome.isolation_country) |>
     dplyr::summarize(n = n()) |>
     dplyr::arrange(desc(n)) |>
@@ -271,6 +271,7 @@ makeTimeSeriesAMRPlot <- function(data, amr_drug) {
       legend.title = element_text(size = 12),
       legend.text = element_text(size = 10),
       axis.text = element_text(size = 10),
+      axis.text.x = element_text(angle = 45, hjust = 1),
       axis.title = element_text(size = 10)
     )
   plotly::ggplotly(g, tooltip = "text")

--- a/R/plots_modelperf.R
+++ b/R/plots_modelperf.R
@@ -322,7 +322,9 @@ makeMCCStripPlot <- function(data, selected_drug_class = NULL,
     plotly::layout(
       title = list(
         text = "MCC per species and molecular scale", x = 0,
-        font = list(size = 13, color = "#333333", family = "Arial, sans-serif")
+        font = list(size = 13, color = "#333333", family = "Arial, sans-serif")),
+        xaxis = list(
+       tickfont = list(size = 10), tickangle = -45
       ),
       margin = list(t = 50)
     )

--- a/R/plots_modelperf.R
+++ b/R/plots_modelperf.R
@@ -57,10 +57,24 @@ makeModelPerformancePlot <- function(
   eskape_order <- c("Efa", "Sau", "Kpn", "Aba", "Pae", "Esp")
   df <- df |>
     dplyr::mutate(species = normalize_species(.data$species))
+
+  # Prefer the full species name (from species_label) over the 3-letter code
+  # for display, matching makeMCCStripPlot()'s .prep_mcc_data() convention.
+  df <- df |>
+    dplyr::mutate(
+      species_display = if ("species_label" %in% names(df)) {
+        gsub("_", " ", .data$species_label)
+      } else {
+        .data$species
+      }
+    )
+
   present <- unique(df$species)
   lvls <- intersect(eskape_order, present)
   if (length(lvls) > 0) {
-    df <- df |> dplyr::mutate(species = factor(.data$species, levels = lvls))
+    display_lvls <- unique(df$species_display[match(lvls, df$species)])
+    df <- df |>
+      dplyr::mutate(species_display = factor(.data$species_display, levels = display_lvls))
   }
 
   # Order feature_type so legend + colors line up with SCALE_COLORS.
@@ -102,7 +116,7 @@ makeModelPerformancePlot <- function(
     p <- p |>
       plotly::add_trace(
         type = "box",
-        x = sub$species,
+        x = sub$species_display,
         y = sub[[metrics]],
         name = ft,
         legendgroup = ft,
@@ -119,7 +133,7 @@ makeModelPerformancePlot <- function(
         p <- p |>
           plotly::add_trace(
             type = "box",
-            x = sub_pts$species,
+            x = sub_pts$species_display,
             y = sub_pts[[metrics]],
             boxpoints = "all",
             pointpos = 0,


### PR DESCRIPTION
Summary
Closes #40. Four fixes to the dashboard:

1) Panel order : "Performance overview" now appears before "Model performance" in the Model performance tab, since it shows all species/drugs unfiltered and makes more sense as the landing view.
2) Species full names : the Model performance panel's box plot showed raw 3-letter codes ("Sfl", "Sso") on its x-axis while the neighboring Performance overview panel already showed full names. Brought it in line using the same species_label convention.
3) Top 5 countries showing NA : found and fixed a real bug: the existing filter !grepl("NA", genome.isolation_country) looked like an NA guard but wasn't one : grepl() returns FALSE (not NA) for NA input, so missing-country rows silently passed the filter. Replaced with !is.na(...).
4) Year-plot label overlap: the AMR-trend-by-year plot had no x-axis text rotation, so year labels overlapped. Added a 45° angle.

Test plan
- [ ] Existing test suite passes
- [ ] Sub-tab order is Performance overview | Model performance
- [ ] Model performance plot x-axis reads Shigella flexneri, Shigella sonnei
- [ ] Top 5 countries card shows only real countries, no NA
- [ ] Year-plot tick labels carry a rotate(-45,...) transform
- [ ] No browser console errors on Model performance, Metadata, or Bug/Drug feature comparison tabs