### PR TITLE
Replace blanket import(shiny) with explicit shiny:: calls throughout

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,6 @@
 
 export(exportAMRVisualizations)
 export(launchAMRDashboard)
-import(shiny)
 importFrom(DT,datatable)
 importFrom(arrow,read_parquet)
 importFrom(arrow,write_parquet)

--- a/R/app.R
+++ b/R/app.R
@@ -13,7 +13,6 @@
 #'
 #' @return A Shiny application object
 #' @export
-#' @import shiny
 #' @importFrom utils head write.csv
 #' @importFrom shinyjs useShinyjs
 #' @examples
@@ -29,11 +28,11 @@ launchAMRDashboard <- function(results_root = NULL,
     if (dir.exists(default_amrdata)) amrdata_root <- default_amrdata
   }
   # UI
-  ui <- tagList(
+  ui <- shiny::tagList(
     shinyjs::useShinyjs(),
-    tags$head(includeCSS(system.file("app/www/style.css", package = "amRviz"))),
-    tags$head(
-      tags$style(HTML("
+    shiny::tags$head(shiny::includeCSS(system.file("app/www/style.css", package = "amRviz"))),
+    shiny::tags$head(
+      shiny::tags$style(shiny::HTML("
                       .innerbox {
                         /*border: 2px solid black;*/
                         box-shadow: 2px 2px 3px 3px #ccc;
@@ -146,85 +145,85 @@ launchAMRDashboard <- function(results_root = NULL,
                     "))
     ),
     # App header: title row separate from the nav tabs
-    tags$div(
+    shiny::tags$div(
       class = "amr-app-header",
-      tags$div(
+      shiny::tags$div(
         class = "amr-app-header-title",
         "amRviz"
       ),
-      tags$div(
+      shiny::tags$div(
         class = "amr-app-header-logo",
-        tags$img(src = "www/logo.png", onerror = "this.style.display='none'")
+        shiny::tags$img(src = "www/logo.png", onerror = "this.style.display='none'")
       )
     ),
-    navbarPage(
+    shiny::navbarPage(
       id = "tabselected",
       selected = "home",
       title = "",
       # 2. Home icon tab (right of AMR dashboard)
-      tabPanel(
-        title = icon("home", class = "home-tab-icon"),
+      shiny::tabPanel(
+        title = shiny::icon("home", class = "home-tab-icon"),
         value = "home",
-        fluidPage(
+        shiny::fluidPage(
           style = "max-width: 960px; margin: 0 auto; padding: 24px 16px;",
 
           # Overview & Features
-          h3("Overview and Features",
+          shiny::h3("Overview and Features",
             style = "font-weight: bold; margin-bottom: 12px;"
           ),
-          tags$p("amRviz allows users to:"),
-          tags$ul(
+          shiny::tags$p("amRviz allows users to:"),
+          shiny::tags$ul(
             style = "line-height: 2; margin-bottom: 16px;",
-            tags$li("Explore AMR model performance across species, drugs, and drug classes."),
-            tags$li("Compare predictive performance across molecular feature scales (gene, protein, domain, structure)."),
-            tags$li("Identify key genomic features driving resistance predictions."),
-            tags$li("Analyze model generalization across geography and time."),
-            tags$li("Visualize and filter isolate metadata and model results interactively.")
+            shiny::tags$li("Explore AMR model performance across species, drugs, and drug classes."),
+            shiny::tags$li("Compare predictive performance across molecular feature scales (gene, protein, domain, structure)."),
+            shiny::tags$li("Identify key genomic features driving resistance predictions."),
+            shiny::tags$li("Analyze model generalization across geography and time."),
+            shiny::tags$li("Visualize and filter isolate metadata and model results interactively.")
           ),
-          tags$p(
+          shiny::tags$p(
             style = "margin-bottom: 28px;",
-            tags$em("amRviz is interactive, modular, and scalable for exploring AMR data and machine learning outputs.")
+            shiny::tags$em("amRviz is interactive, modular, and scalable for exploring AMR data and machine learning outputs.")
           ),
 
           # Workflow figure
-          div(
+          shiny::div(
             style = "text-align: center; margin-bottom: 32px;",
-            tags$img(
+            shiny::tags$img(
               src = "www/amr_overview.png",
               style = "max-width: 70%; border-radius: 6px; box-shadow: 0 2px 10px rgba(0,0,0,0.12);",
               onerror = "this.style.display='none'"
             )
           ),
-          tags$hr(),
-          h2("amR: an R package suite to predict antimicrobial resistance in bacterial pathogens"),
-          tags$p(
-            tags$strong("Authors: "),
+          shiny::tags$hr(),
+          shiny::h2("amR: an R package suite to predict antimicrobial resistance in bacterial pathogens"),
+          shiny::tags$p(
+            shiny::tags$strong("Authors: "),
             "Evan P Brenner^, Abhirupa Ghosh^, Emily A Boyer, Charmie K Vang, Ethan P Wolfe, Alexander P McKim, Raymond L Lesiyon, David Mayer, Janani Ravi*."
           ),
-          tags$p(
+          shiny::tags$p(
             "Department of Biomedical Informatics, Center for Health Artificial Intelligence, University of Colorado Anschutz, Aurora, CO 80045.",
-            tags$span(style = "font-style: italic", " ^Co-primary authors contributing equally. *Corresponding author: janani.ravi@cuanschutz.edu")
+            shiny::tags$span(style = "font-style: italic", " ^Co-primary authors contributing equally. *Corresponding author: janani.ravi@cuanschutz.edu")
           ),
-          tags$p(
-            tags$strong("Keywords: "),
+          shiny::tags$p(
+            shiny::tags$strong("Keywords: "),
             "antimicrobial resistance, machine learning, bacterial genomics, pangenomics, interpretable models, drug resistance prediction, multiscale features, R package"
           ),
-          br(),
-          h4("Abstract"),
-          tags$strong("Motivation: "),
-          tags$p("Identifying antimicrobial resistance (AMR) in bacterial pathogens is critical for diagnostics and treatment, but resistance is a complex trait arising from diverse mechanisms spanning multiple molecular scales. Existing computational approaches often function as black boxes and rarely explore cross-species or multi-drug patterns. We developed amR, an integrated R package suite providing a complete framework from bacterial genome sequences to interpretable AMR predictions, enabling identification of resistance mechanisms across species and drugs."),
-          tags$strong("Results: "),
-          tags$p("The amR suite contains three modular packages. amRdata interfaces with BV-BRC to download and process bacterial genomes with paired antimicrobial susceptibility testing data, constructs pangenomes, and extracts features at gene/protein cluster, protein domain, and structural variant scales, along with annotating protein clusters with Clusters of Orthologous Genes and ResFinder AMR-associated features. Data are stored in memory-efficient Parquet and DuckDB formats. amRml trains interpretable machine learning models per species-drug combination, calculates feature importance and comprehensive performance metrics, and provides rich ground for mechanism discovery. amRviz provides an interactive Shiny dashboard to explore metadata distributions, model performance across species and drugs, visualize top predictive AMR features, and analyze cross-model patterns (including across geographic/temporal strata). The suite has been applied to ESKAPE pathogens, achieving balanced accuracies above 0.80. With thousands of genomes, multi-scale features, and interpretable models, amR provides an accessible, comprehensive framework for AMR research."),
-          tags$strong("Availability and implementation: "),
-          tags$p(
+          shiny::br(),
+          shiny::h4("Abstract"),
+          shiny::tags$strong("Motivation: "),
+          shiny::tags$p("Identifying antimicrobial resistance (AMR) in bacterial pathogens is critical for diagnostics and treatment, but resistance is a complex trait arising from diverse mechanisms spanning multiple molecular scales. Existing computational approaches often function as black boxes and rarely explore cross-species or multi-drug patterns. We developed amR, an integrated R package suite providing a complete framework from bacterial genome sequences to interpretable AMR predictions, enabling identification of resistance mechanisms across species and drugs."),
+          shiny::tags$strong("Results: "),
+          shiny::tags$p("The amR suite contains three modular packages. amRdata interfaces with BV-BRC to download and process bacterial genomes with paired antimicrobial susceptibility testing data, constructs pangenomes, and extracts features at gene/protein cluster, protein domain, and structural variant scales, along with annotating protein clusters with Clusters of Orthologous Genes and ResFinder AMR-associated features. Data are stored in memory-efficient Parquet and DuckDB formats. amRml trains interpretable machine learning models per species-drug combination, calculates feature importance and comprehensive performance metrics, and provides rich ground for mechanism discovery. amRviz provides an interactive Shiny dashboard to explore metadata distributions, model performance across species and drugs, visualize top predictive AMR features, and analyze cross-model patterns (including across geographic/temporal strata). The suite has been applied to ESKAPE pathogens, achieving balanced accuracies above 0.80. With thousands of genomes, multi-scale features, and interpretable models, amR provides an accessible, comprehensive framework for AMR research."),
+          shiny::tags$strong("Availability and implementation: "),
+          shiny::tags$p(
             "amR is developed in R. We use Dockerized software for data curation and feature extraction, perform modeling with the tidymodels framework, and visualize results using Shiny. The suite is available at: ",
-            tags$a(href = "https://github.com/JRaviLab/amR", "https://github.com/JRaviLab/amR"), "."
+            shiny::tags$a(href = "https://github.com/JRaviLab/amR", "https://github.com/JRaviLab/amR"), "."
           ),
-          tags$p(
-            tags$strong("Contact: "),
-            tags$a(href = "mailto:janani.ravi@cuanschutz.edu", "janani.ravi@cuanschutz.edu")
+          shiny::tags$p(
+            shiny::tags$strong("Contact: "),
+            shiny::tags$a(href = "mailto:janani.ravi@cuanschutz.edu", "janani.ravi@cuanschutz.edu")
           ),
-          tags$hr(),
+          shiny::tags$hr(),
         )
       ),
       # other tabs
@@ -235,17 +234,17 @@ launchAMRDashboard <- function(results_root = NULL,
       networkUI(),
       queryDataUI()
     ),
-    tags$footer(
+    shiny::tags$footer(
       class = "footer",
-      tags$div(
+      shiny::tags$div(
         "(c) JRaviLab 2026 | ",
-        tags$a(href = "https://jravilab.github.io", "jravilab.github.io"),
+        shiny::tags$a(href = "https://jravilab.github.io", "jravilab.github.io"),
         " | ",
-        tags$a(href = "https://twitter.com/jravilab", "@jravilab"),
+        shiny::tags$a(href = "https://twitter.com/jravilab", "@jravilab"),
         " | janani.ravi@cuanschutz.edu |",
-        tags$a(
+        shiny::tags$a(
           href = "https://docs.google.com/forms/d/e/1FAIpQLSdwFo5Wwt_t4WGthDGgc1EYhvvKagUEb3RiNLdsbnpDlYTk7Q/viewform?usp=dialog",
-          icon("question-circle"),
+          shiny::icon("question-circle"),
           " Help Doc"
         )
       )

--- a/R/crossModelComparisonUI.R
+++ b/R/crossModelComparisonUI.R
@@ -2,45 +2,45 @@
 #' @return A tabPanel for cross model comparison visualization
 #' @keywords internal
 crossModelComparisonUI <- function() {
-  tabPanel(
+  shiny::tabPanel(
     title = "Model holdouts",
-    icon = icon("clock"),
-    fluidRow(
-      h3("Model Holdouts Comparison",
+    icon = shiny::icon("clock"),
+    shiny::fluidRow(
+      shiny::h3("Model Holdouts Comparison",
         style = "margin-top: 15px; margin-bottom: 15px; font-weight: bold;"
       ),
       style = "padding: 10px;",
-      tagList(
-        column(
+      shiny::tagList(
+        shiny::column(
           width = 4,
           style = "height: 80px; display: flex; align-items: center;",
-          selectInput(
+          shiny::selectInput(
             inputId = "bug_cross_model_comparison_id",
-            label = tags$label("Bug", style = "font-size: 15px;"),
+            label = shiny::tags$label("Bug", style = "font-size: 15px;"),
             choices = character(0),
             multiple = FALSE,
             selectize = TRUE,
             width = "100%"
           )
         ),
-        column(
+        shiny::column(
           width = 4,
           style = "height: 80px; display: flex; align-items: center;",
-          selectInput(
+          shiny::selectInput(
             inputId = "drug_cross_model_comparison_id",
-            label = tags$label("Drug/Drug class", style = "font-size: 15px;"),
+            label = shiny::tags$label("Drug/Drug class", style = "font-size: 15px;"),
             choices = NULL,
             multiple = FALSE,
             selectize = TRUE,
             width = "100%"
           )
         ),
-        column(
+        shiny::column(
           width = 4,
           style = "height: 80px; display: flex; align-items: center;",
-          radioButtons(
+          shiny::radioButtons(
             inputId = "cross_model_comparison",
-            label = tags$label("Cross-train models across",
+            label = shiny::tags$label("Cross-train models across",
               style = "font-size: 15px;"
             ),
             choices = c(
@@ -53,27 +53,27 @@ crossModelComparisonUI <- function() {
         )
       )
     ),
-    column(
+    shiny::column(
       width = 12, offset = 0,
-      mainPanel(
+      shiny::mainPanel(
         width = 12,
         style = "padding: 0;",
-        tabsetPanel(
+        shiny::tabsetPanel(
           id = "cross_model_comparison_tabset",
           type = "tabs",
           # Tab 1: Accuracy distributions
-          tabPanel(
+          shiny::tabPanel(
             "Accuracy distributions",
-            fluidRow(
+            shiny::fluidRow(
               style = "padding: 10px;",
-              column(
+              shiny::column(
                 width = 6,
                 plotly::plotlyOutput("cross_model_ridge_country",
                   height = "400px"
                 ),
                 style = "padding: 5px; border: 1px solid lightgray;"
               ),
-              column(
+              shiny::column(
                 width = 6,
                 plotly::plotlyOutput("cross_model_ridge_time",
                   height = "400px"
@@ -83,18 +83,18 @@ crossModelComparisonUI <- function() {
             )
           ),
           # Tab 2: Model performance heatmaps
-          tabPanel(
+          shiny::tabPanel(
             "Model performance",
-            fluidRow(
+            shiny::fluidRow(
               style = "padding: 10px;",
-              column(
+              shiny::column(
                 width = 6,
                 plotly::plotlyOutput("cross_model_perf_country",
                   height = "400px"
                 ),
                 style = "padding: 5px; border: 1px solid lightgray;"
               ),
-              column(
+              shiny::column(
                 width = 6,
                 plotly::plotlyOutput("cross_model_perf_time",
                   height = "400px"
@@ -104,15 +104,15 @@ crossModelComparisonUI <- function() {
             )
           ),
           # Tab 3: Top features
-          tabPanel(
+          shiny::tabPanel(
             "Top features",
-            tagList(
-              fluidRow(
-                column(
+            shiny::tagList(
+              shiny::fluidRow(
+                shiny::column(
                   width = 4,
-                  div(
+                  shiny::div(
                     style = "padding: 10px;",
-                    sliderInput(
+                    shiny::sliderInput(
                       inputId = "cross_model_top_n_features",
                       label = "Top features",
                       min = 0, max = 100, value = 10
@@ -120,8 +120,8 @@ crossModelComparisonUI <- function() {
                   )
                 )
               ),
-              fluidRow(
-                column(
+              shiny::fluidRow(
+                shiny::column(
                   width = 6,
                   plotly::plotlyOutput(
                     "cross_model_feature_importance_plot",
@@ -132,7 +132,7 @@ crossModelComparisonUI <- function() {
                     " border: 1px solid lightgray;"
                   )
                 ),
-                column(
+                shiny::column(
                   width = 6,
                   DT::dataTableOutput(
                     "cross_model_feature_importance_table"

--- a/R/featureImportanceUI.R
+++ b/R/featureImportanceUI.R
@@ -2,66 +2,66 @@
 #' @return A tabPanel for feature importance visualization
 #' @keywords internal
 featureImportanceUI <- function() {
-  tabPanel(
+  shiny::tabPanel(
     title = "Bug/Drug feature comparison",
-    icon = icon("bug"),
-    fluidRow(
-      h3("Feature Importance Comparison", style = "margin-top: 15px; margin-bottom: 15px; font-weight: bold;"),
+    icon = shiny::icon("bug"),
+    shiny::fluidRow(
+      shiny::h3("Feature Importance Comparison", style = "margin-top: 15px; margin-bottom: 15px; font-weight: bold;"),
       style = "padding: 10px;",
-      column(
+      shiny::column(
         width = 4,
         style = "height: 80px; display: flex; align-items: center;",
-        selectInput(
+        shiny::selectInput(
           "bug_drug_comp_model_scale",
-          label = tags$label("Model scale", style = "font-size: 15px;"),
+          label = shiny::tags$label("Model scale", style = "font-size: 15px;"),
           choices = c("genes", "domains", "proteins", "cogs", "args"),
           multiple = FALSE,
           selectize = TRUE,
           selected = "genes"
         )
       ),
-      column(
+      shiny::column(
         width = 4,
         style = "height: 80px; display: flex; align-items: center;",
-        selectInput(
+        shiny::selectInput(
           "feature_data_type",
-          label = tags$label("Data type", style = "font-size: 15px;"),
+          label = shiny::tags$label("Data type", style = "font-size: 15px;"),
           choices = c("count" = "counts", "binary" = "binary"),
           multiple = FALSE,
           selectize = TRUE,
           selected = c("counts", "binary")
         )
       ),
-      column(
+      shiny::column(
         width = 4,
         style = "height: 80px; display: flex; align-items: center;",
-        div(
-          sliderInput(inputId = "top_n_features", label = "Top features (per model)", min = 0, max = 100, value = 10)
+        shiny::div(
+          shiny::sliderInput(inputId = "top_n_features", label = "Top features (per model)", min = 0, max = 100, value = 10)
         )
       )
     ),
-    column(
+    shiny::column(
       width = 12, offset = 0,
-      mainPanel(
+      shiny::mainPanel(
         width = 12,
         style = "padding: 0;",
-        tabsetPanel(
+        shiny::tabsetPanel(
           id = "feature_importance_tabset",
           type = "tabs",
-          tabPanel(
+          shiny::tabPanel(
             "Across bugs",
             value = "across_bug",
-            tagList(
-              fluidRow(
-                column(
+            shiny::tagList(
+              shiny::fluidRow(
+                shiny::column(
                   width = 6,
                   style = "height: 50px; display: flex; align-items: center;",
-                  h4("Toggle the button to select drug or drug class")
+                  shiny::h4("Toggle the button to select drug or drug class")
                 ),
-                column(
+                shiny::column(
                   width = 4,
                   style = "height: 50px; display: flex; align-items: center;",
-                  radioButtons(
+                  shiny::radioButtons(
                     inputId = "across_bug_id",
                     label = "",
                     choices = c("Drug class" = "drug_class", "Drug" = "drug"),
@@ -70,46 +70,46 @@ featureImportanceUI <- function() {
                   )
                 )
               ),
-              fluidRow(
+              shiny::fluidRow(
                 # Bug selector is the same in both modes, so define it once
                 # outside the conditional panels (avoids a duplicate input id).
-                column(
+                shiny::column(
                   width = 6, style = "padding: 0;",
                   amr_select("bug_search_amr_across_bug", "Bug (multi-select)", character(0), selected = NULL)
                 ),
-                conditionalPanel(
+                shiny::conditionalPanel(
                   condition = "input.across_bug_id == 'drug'",
-                  column(
+                  shiny::column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_across_bug", "Drug", NULL, FALSE)
                   )
                 ),
-                conditionalPanel(
+                shiny::conditionalPanel(
                   condition = "input.across_bug_id == 'drug_class'",
-                  column(
+                  shiny::column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_class_across_bug", "Drug class", NULL, FALSE)
                   )
                 )
               ),
-              column(
+              shiny::column(
                 width = 6,
                 style = "padding: 0; height: 600px; border: 1px solid lightgray;",
                 plotly::plotlyOutput("across_bug_feature_importance_plot", height = "100%", width = "100%")
               ),
-              column(
+              shiny::column(
                 width = 6,
                 style = "padding: 0; height: 600px; border: 1px solid lightgray;",
                 DT::dataTableOutput("across_bug_feature_importance_table", height = "100%")
               ),
-              fluidRow(
+              shiny::fluidRow(
                 style = "padding: 10px 0;",
-                column(
+                shiny::column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
                   plotly::plotlyOutput("across_bug_cog_barplot", height = "100%")
                 ),
-                column(
+                shiny::column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
                   networkD3::forceNetworkOutput("across_bug_ego_network", height = "100%")
@@ -117,20 +117,20 @@ featureImportanceUI <- function() {
               )
             )
           ),
-          tabPanel(
+          shiny::tabPanel(
             "Across drugs",
             value = "across_drug",
-            tagList(
-              fluidRow(
-                column(
+            shiny::tagList(
+              shiny::fluidRow(
+                shiny::column(
                   width = 6,
                   style = "height: 50px; display: flex; align-items: center;",
-                  h4("Toggle the button to select drug or drug class")
+                  shiny::h4("Toggle the button to select drug or drug class")
                 ),
-                column(
+                shiny::column(
                   width = 4,
                   style = "height: 50px; display: flex; align-items: center;",
-                  radioButtons(
+                  shiny::radioButtons(
                     inputId = "across_drug_id",
                     label = "",
                     choices = c("Drug class" = "drug_class", "Drug" = "drug"),
@@ -139,46 +139,46 @@ featureImportanceUI <- function() {
                   )
                 )
               ),
-              fluidRow(
+              shiny::fluidRow(
                 # Bug selector is the same in both modes, so define it once
                 # outside the conditional panels (avoids a duplicate input id).
-                column(
+                shiny::column(
                   width = 6, style = "padding: 0;",
                   amr_select("bug_search_amr_across_drug", "Bug", character(0), selected = NULL, multiple = FALSE)
                 ),
-                conditionalPanel(
+                shiny::conditionalPanel(
                   condition = "input.across_drug_id == 'drug'",
-                  column(
+                  shiny::column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_across_drug", "Drug (multi-select)", NULL)
                   )
                 ),
-                conditionalPanel(
+                shiny::conditionalPanel(
                   condition = "input.across_drug_id == 'drug_class'",
-                  column(
+                  shiny::column(
                     width = 6, style = "padding: 0;",
                     amr_select("amr_drug_class_across_drug", "Drug class (multi-select)", NULL)
                   )
                 )
               ),
-              column(
+              shiny::column(
                 width = 6, style = "padding: 0;",
                 plotly::plotlyOutput("across_drug_feature_importance_plot", height = "100%"),
                 style = "padding: 0; height: 600px; border: 1px solid lightgray;"
               ),
-              column(
+              shiny::column(
                 width = 6,
                 style = "padding: 0; height: 600px; border: 1px solid lightgray;",
                 DT::dataTableOutput("across_drug_feature_importance_table", height = "100%")
               ),
-              fluidRow(
+              shiny::fluidRow(
                 style = "padding: 10px 0;",
-                column(
+                shiny::column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
                   plotly::plotlyOutput("across_drug_cog_barplot", height = "100%")
                 ),
-                column(
+                shiny::column(
                   width = 6,
                   style = "padding: 0; border: 1px solid lightgray; height: 350px;",
                   networkD3::forceNetworkOutput("across_drug_ego_network", height = "100%")

--- a/R/metadataUI.R
+++ b/R/metadataUI.R
@@ -2,12 +2,12 @@
 #' @return A tabPanel for metadata visualization
 #' @keywords internal
 metadataUI <- function() {
-  tabPanel(
+  shiny::tabPanel(
     title = "Metadata",
-    icon = icon("globe"),
-    fluidPage(
+    icon = shiny::icon("globe"),
+    shiny::fluidPage(
       # Main Content Section
-      column(
+      shiny::column(
         width = 12,
         amr_select(
           "bug_metadata_id",
@@ -17,23 +17,23 @@ metadataUI <- function() {
           selected = NULL
         )
       ),
-      fluidRow(
+      shiny::fluidRow(
         # Quick Stats Section
-        column(
+        shiny::column(
           width = 12,
-          div(
+          shiny::div(
             class = "quick-stats-container",
             style = "padding: 10px; margin-bottom: 20px; border: 1px solid lightgray; border-radius: 5px;",
-            uiOutput("quick_metadata_stats")
+            shiny::uiOutput("quick_metadata_stats")
           )
         )
       ),
-      fluidRow(
-        column(
+      shiny::fluidRow(
+        shiny::column(
           width = 6,
-          div(
+          shiny::div(
             class = "plot-container",
-            div(
+            shiny::div(
               class = "plot-header",
               style = "text-align: center; font-family: 'Arial', sans-serif; font-size: 14px; margin-top: 8px; margin-bottom: 8px;",
               "Distribution of AMR phenotypes"
@@ -41,11 +41,11 @@ metadataUI <- function() {
             styledBox("resistance_vs_susceptible_ui")
           )
         ),
-        column(
+        shiny::column(
           width = 6,
-          div(
+          shiny::div(
             class = "plot-container",
-            div(
+            shiny::div(
               class = "plot-header",
               style = "text-align: center; font-family: 'Arial', sans-serif; font-size: 14px; margin-top: 8px; margin-bottom: 8px;",
               "Global distribution of resistant phenotypes"
@@ -54,12 +54,12 @@ metadataUI <- function() {
           )
         )
       ),
-      fluidRow(
-        column(
+      shiny::fluidRow(
+        shiny::column(
           width = 6,
-          div(
+          shiny::div(
             class = "plot-container",
-            div(
+            shiny::div(
               class = "plot-header",
               style = "text-align: center; font-family: 'Arial', sans-serif; font-size: 14px; margin-top: 8px; margin-bottom: 8px;",
               "Distribution of AMR phenotypes by year"
@@ -67,19 +67,19 @@ metadataUI <- function() {
             styledBox("r_s_across_time_ui")
           )
         ),
-        column(
+        shiny::column(
           width = 6,
-          div(
+          shiny::div(
             class = "plot-container",
-            uiOutput("isolation_source_header"),
+            shiny::uiOutput("isolation_source_header"),
             tabBox(
               id = "isolation_source_tabset",
               width = 12,
-              tabPanel(
+              shiny::tabPanel(
                 "Isolation sources",
                 styledBox("isolation_source_ui")
               ),
-              tabPanel(
+              shiny::tabPanel(
                 "Hosts",
                 styledBox("host_isolate_plot_ui")
               )
@@ -87,12 +87,12 @@ metadataUI <- function() {
           )
         )
       ),
-      fluidRow(
-        column(
+      shiny::fluidRow(
+        shiny::column(
           width = 12,
-          div(
+          shiny::div(
             class = "plot-container",
-            div(
+            shiny::div(
               class = "plot-header",
               style = paste0(
                 "text-align: center; font-family: 'Arial', sans-serif;",
@@ -104,11 +104,11 @@ metadataUI <- function() {
                 "country -> host -> isolation source"
               )
             ),
-            div(
+            shiny::div(
               style = "padding: 0 10px;",
-              selectInput(
+              shiny::selectInput(
                 inputId = "metadata_sankey_classes",
-                label = tags$label(
+                label = shiny::tags$label(
                   "Drug classes (top 3 by default)",
                   style = "font-size: 13px;"
                 ),

--- a/R/modelPerfUI.R
+++ b/R/modelPerfUI.R
@@ -2,15 +2,15 @@
 #' @return A tabPanel for model performance visualization
 #' @keywords internal
 modelPerfUI <- function() {
-  tabPanel(
+  shiny::tabPanel(
     title = "Model performance",
     value = "model_perf_tab",
-    icon = icon("chart-line"),
-    fluidRow(
-      column(
+    icon = shiny::icon("chart-line"),
+    shiny::fluidRow(
+      shiny::column(
         width = 4,
-        div(
-          h3("Model Performance", style = "margin-top: 15px; margin-bottom: 15px; font-weight: bold;"),
+        shiny::div(
+          shiny::h3("Model Performance", style = "margin-top: 15px; margin-bottom: 15px; font-weight: bold;"),
           amr_select(
             "bug_perf_id", "Bug",
             character(0),
@@ -19,58 +19,58 @@ modelPerfUI <- function() {
           )
         )
       ),
-      column(
+      shiny::column(
         width = 4,
         style = "padding-top: 52px;",
         amr_select("drug_class_perf_id", "Drug class", NULL, FALSE)
       ),
-      column(
+      shiny::column(
         width = 4,
         style = "padding-top: 52px;",
         amr_select("drug_perf_id", "Drug", NULL, FALSE)
       )
     ),
-    column(
+    shiny::column(
       width = 12,
-      mainPanel(
+      shiny::mainPanel(
         width = 12,
         style = "padding: 0;",
-        tabsetPanel(
-          tabPanel(
+        shiny::tabsetPanel(
+          shiny::tabPanel(
             "Performance overview",
-            fluidPage(
-              tags$p(
+            shiny::fluidPage(
+              shiny::tags$p(
                 style = "color: #555; font-size: 10px; padding-top: 10px;",
                 "Only baseline models from all the available species. ",
                 "Left: MCC distribution per species and molecular scale. ",
                 "Right: median MCC by drug class across species, ",
                 "molecular scale, and data encoding."
               ),
-              fluidRow(
-                column(4, plotly::plotlyOutput(
+              shiny::fluidRow(
+                shiny::column(4, plotly::plotlyOutput(
                   "mcc_strip_plot",
                   height = "420px"
                 )),
-                column(8, plotly::plotlyOutput(
+                shiny::column(8, plotly::plotlyOutput(
                   "mcc_heatmap",
                   height = "420px"
                 ))
               )
             )
           ),
-          tabPanel(
+          shiny::tabPanel(
             "Model performance",
-             fluidPage(
-              tags$p(
+             shiny::fluidPage(
+              shiny::tags$p(
                 style = "color: #555; font-size: 10px; padding-top: 10px;","The filter options above allow to select a subset of species, drug classes, and drugs. ",
                 "The filter options below allow to select the model scale and data type")),
-            tagList(
-              fluidRow(
-                column(
+            shiny::tagList(
+              shiny::fluidRow(
+                shiny::column(
                   width = 4,
-                  selectInput(
+                  shiny::selectInput(
                     "model_scale",
-                    label = tags$label("Model scale", style = "font-size: 15px;"),
+                    label = shiny::tags$label("Model scale", style = "font-size: 15px;"),
                     choices = c("genes", "domains", "proteins", "cogs", "args"),
                     multiple = TRUE,
                     selectize = TRUE,
@@ -78,11 +78,11 @@ modelPerfUI <- function() {
                     width = "80%"
                   )
                 ),
-                column(
+                shiny::column(
                   width = 4,
-                  selectInput(
+                  shiny::selectInput(
                     "data_type",
-                    label = tags$label("Data type", style = "font-size: 15px;"),
+                    label = shiny::tags$label("Data type", style = "font-size: 15px;"),
                     choices = c("count" = "counts", "binary" = "binary"),
                     multiple = FALSE,
                     selectize = TRUE,
@@ -90,13 +90,13 @@ modelPerfUI <- function() {
                     selected = c("binary")
                   )
                 ),
-                column(
+                shiny::column(
                   width = 4,
-                  div(
+                  shiny::div(
                     style = "display:none; padding: 10px;",
-                    selectInput(
+                    shiny::selectInput(
                       "model_metrics",
-                      label = tags$label("Performance metric", style = "font-size: 15px;"),
+                      label = shiny::tags$label("Performance metric", style = "font-size: 15px;"),
                       choices = c("Matthews Correlation Coefficient" = "mcc"),
                       multiple = FALSE,
                       selectize = TRUE,
@@ -105,9 +105,9 @@ modelPerfUI <- function() {
                   )
                 )
               ),
-              column(
+              shiny::column(
                 width = 12,
-                div(
+                shiny::div(
                   style = "height: 600px;",
                   plotly::plotlyOutput("model_perfomance_plot", height = "100%")
                 )

--- a/R/networkUI.R
+++ b/R/networkUI.R
@@ -2,54 +2,54 @@
 #' @return A tabPanel for drug-feature network visualization
 #' @keywords internal
 networkUI <- function() {
-  tabPanel(
+  shiny::tabPanel(
     title = "Network",
-    icon = icon("circle-nodes"),
-    fluidPage(
-      h3("Drug-Feature Network",
+    icon = shiny::icon("circle-nodes"),
+    shiny::fluidPage(
+      shiny::h3("Drug-Feature Network",
         style = paste0(
           "font-weight: bold; margin-top: 15px; margin-bottom: 15px;"
         )
       ),
-      p(paste(
+      shiny::p(paste(
         "Interactive force-directed graph linking drugs or drug classes",
         "(orange) to their top predictive features (blue).",
         "Drag nodes, zoom, and hover for labels."
       )),
-      fluidRow(
-        column(
+      shiny::fluidRow(
+        shiny::column(
           width = 3,
           style = "padding: 10px;",
-          selectInput(
+          shiny::selectInput(
             inputId = "network_bug_id",
-            label = tags$label("Bug", style = "font-size: 15px;"),
+            label = shiny::tags$label("Bug", style = "font-size: 15px;"),
             choices = character(0),
             multiple = FALSE,
             selectize = TRUE,
             width = "100%"
           )
         ),
-        column(
+        shiny::column(
           width = 3,
           style = "padding: 10px;",
-          sliderInput(
+          shiny::sliderInput(
             inputId = "network_top_n",
-            label = tags$label(
+            label = shiny::tags$label(
               "Top features per drug",
               style = "font-size: 15px;"
             ),
             min = 1, max = 30, value = 5
           )
         ),
-        column(
+        shiny::column(
           width = 3,
           style = "padding: 10px;",
-          checkboxInput(
+          shiny::checkboxInput(
             inputId = "network_include_clusters",
             label = "Show clusters",
             value = FALSE
           ),
-          tags$span(
+          shiny::tags$span(
             "Adds cluster (fig) nodes from annotations.",
             style = "font-size: 11px; color: #666;"
           )
@@ -69,8 +69,8 @@ networkUI <- function() {
         #   )
         # )
       ),
-      fluidRow(
-        column(
+      shiny::fluidRow(
+        shiny::column(
           width = 12,
           shinycssloaders::withSpinner(
             networkD3::forceNetworkOutput(

--- a/R/plots_metadata.R
+++ b/R/plots_metadata.R
@@ -13,7 +13,7 @@
 #' @noRd
 quickStatBox <- function(title, value, icon_name, bg_color,
                          text_color = "white") {
-  div(
+  shiny::div(
     style = glue::glue("
       background-color: {bg_color};
       color: {text_color};
@@ -27,19 +27,19 @@ quickStatBox <- function(title, value, icon_name, bg_color,
       min-height: 55px;
       font-family: sans-serif;
     "),
-    div(
-      div(
+    shiny::div(
+      shiny::div(
         style = "font-size: 18px; font-weight: bold; line-height: 1.2;",
         value
       ),
-      div(
+      shiny::div(
         style = "font-size: 11px; margin-top: 3px; opacity: 0.9;",
         title
       )
     ),
-    div(
+    shiny::div(
       style = "font-size: 24px; opacity: 0.4;",
-      icon(icon_name)
+      shiny::icon(icon_name)
     )
   )
 }
@@ -92,44 +92,44 @@ makeQuickStats <- function(data) {
     dplyr::slice_head(n = 5) |>
     dplyr::pull(genome.isolation_country)
   spp_name <- unique(data_with_drug_class$species)
-  summary_paragraph <- tags$p(
+  summary_paragraph <- shiny::tags$p(
     style = "font-weight: bold; padding: 4px 4px 4px; font-family: sans-serif; font-size: 14px;",
     stringr::str_glue("Data summary for {stringr::str_to_sentence(spp_name[1])}")
   )
-  tagList(
+  shiny::tagList(
     summary_paragraph,
-    fluidRow(
-      column(4, quickStatBox("Isolate-drug records", total_genomes, "database", "#3c5a6f")),
-      column(4, quickStatBox("Unique genomes", total_uniques_genomes, "dna", "#7aab6e")),
-      column(4, quickStatBox("Drugs tested", n_amr_drugs, "pills", "#9b7fba"))
+    shiny::fluidRow(
+      shiny::column(4, quickStatBox("Isolate-drug records", total_genomes, "database", "#3c5a6f")),
+      shiny::column(4, quickStatBox("Unique genomes", total_uniques_genomes, "dna", "#7aab6e")),
+      shiny::column(4, quickStatBox("Drugs tested", n_amr_drugs, "pills", "#9b7fba"))
     ),
-    fluidRow(
-      column(4, quickStatBox("Resistant isolates", n_genomes_resistant, "virus", "#d4872a")),
-      column(4, quickStatBox("Susceptible isolates", n_genomes_susceptible, "shield-halved", "#8a8a8a")),
-      column(4, quickStatBox("Drug classes", n_amr_drug_class, "layer-group", "#8b6b7a"))
+    shiny::fluidRow(
+      shiny::column(4, quickStatBox("Resistant isolates", n_genomes_resistant, "virus", "#d4872a")),
+      shiny::column(4, quickStatBox("Susceptible isolates", n_genomes_susceptible, "shield-halved", "#8a8a8a")),
+      shiny::column(4, quickStatBox("Drug classes", n_amr_drug_class, "layer-group", "#8b6b7a"))
     ),
-    fluidRow(
-      column(4, quickStatBox(
+    shiny::fluidRow(
+      shiny::column(4, quickStatBox(
         "Top 5 drugs",
-        tags$span(
+        shiny::tags$span(
           style = "font-size:11px; line-height:1.5;",
-          HTML(paste(top_n_drugs, collapse = "<br/>"))
+          shiny::HTML(paste(top_n_drugs, collapse = "<br/>"))
         ),
         "star", "#4e9a9a"
       )),
-      column(4, quickStatBox(
+      shiny::column(4, quickStatBox(
         "Top 5 drug classes",
-        tags$span(
+        shiny::tags$span(
           style = "font-size:11px; line-height:1.5;",
-          HTML(paste(top_n_drugs_class, collapse = "<br/>"))
+          shiny::HTML(paste(top_n_drugs_class, collapse = "<br/>"))
         ),
         "list", "#6a6f4e"
       )),
-      column(4, quickStatBox(
+      shiny::column(4, quickStatBox(
         "Top 5 countries",
-        tags$span(
+        shiny::tags$span(
           style = "font-size:11px; line-height:1.5;",
-          HTML(paste(top_n_countries, collapse = "<br/>"))
+          shiny::HTML(paste(top_n_countries, collapse = "<br/>"))
         ),
         "globe", "#d4735e"
       ))

--- a/R/queryDataUI.R
+++ b/R/queryDataUI.R
@@ -2,25 +2,25 @@
 #' @return A tabPanel for querying and downloading data
 #' @keywords internal
 queryDataUI <- function() {
-  tabPanel(
+  shiny::tabPanel(
     title = "Query Data",
-    icon = icon("table", lib = "font-awesome"),
+    icon = shiny::icon("table", lib = "font-awesome"),
     value = "query_datatable",
-    fluidPage(
-      h2("Query Data"),
-      p("The data table provides the ability to download the raw data for model performance metrics and top features. The table can be customized by adding/removing specific columns."),
-      uiOutput("results_species_selector_ui"),
-      tabsetPanel(
+    shiny::fluidPage(
+      shiny::h2("Query Data"),
+      shiny::p("The data table provides the ability to download the raw data for model performance metrics and top features. The table can be customized by adding/removing specific columns."),
+      shiny::uiOutput("results_species_selector_ui"),
+      shiny::tabsetPanel(
         id = "query_tabset",
 
         # Performance Metrics Tab
-        tabPanel(
+        shiny::tabPanel(
           title = "Performance Metrics",
           value = "performance_metrics_tab",
-          fluidRow(
-            column(
+          shiny::fluidRow(
+            shiny::column(
               width = 4,
-              selectizeInput(
+              shiny::selectizeInput(
                 inputId = "query_data_columns",
                 label = "Add/Remove Column(s)",
                 choices = NULL, # Dynamically updated in the server
@@ -34,20 +34,20 @@ queryDataUI <- function() {
                 )
               )
             ),
-            column(
+            shiny::column(
               width = 4,
               offset = 4,
               align = "right",
               # Download button for the customized table
-              downloadButton(
+              shiny::downloadButton(
                 outputId = "query_data_download",
                 label = "Download Selected Data (CSV)",
                 class = "btn btn-success"
               )
             )
           ),
-          fluidRow(
-            column(
+          shiny::fluidRow(
+            shiny::column(
               shinycssloaders::withSpinner(DT::dataTableOutput(outputId = "queryDataTable")),
               width = 12,
               style = "overflow-x: auto; border: 1px solid lightgray;" # Add styling
@@ -56,13 +56,13 @@ queryDataUI <- function() {
         ),
 
         # Top Features Tab
-        tabPanel(
+        shiny::tabPanel(
           title = "Top Features",
           value = "top_features_tab",
-          fluidRow(
-            column(
+          shiny::fluidRow(
+            shiny::column(
               width = 4,
-              selectizeInput(
+              shiny::selectizeInput(
                 inputId = "top_features_columns",
                 label = "Add/Remove Column(s)",
                 choices = NULL, # Dynamically updated in the server
@@ -76,20 +76,20 @@ queryDataUI <- function() {
                 )
               )
             ),
-            column(
+            shiny::column(
               width = 4,
               offset = 4,
               align = "right",
               # Download button for Top Features table
-              downloadButton(
+              shiny::downloadButton(
                 outputId = "top_features_download",
                 label = "Download Selected Data (CSV)",
                 class = "btn btn-success"
               )
             )
           ),
-          fluidRow(
-            column(
+          shiny::fluidRow(
+            shiny::column(
               shinycssloaders::withSpinner(DT::dataTableOutput(outputId = "topFeaturesTable")),
               width = 12,
               style = "overflow-x: auto; border: 1px solid lightgray;" # Add styling

--- a/R/utils_ui.R
+++ b/R/utils_ui.R
@@ -11,12 +11,12 @@
 #' @keywords internal
 #' @noRd
 amr_button <- function(id, label, icon_name, class_name) {
-  div(
+  shiny::div(
     style = "padding: 5px; text-align: center;",
-    actionButton(
+    shiny::actionButton(
       inputId = id,
-      label = tags$label(label, style = "font-size: 15px;"),
-      icon = icon(icon_name),
+      label = shiny::tags$label(label, style = "font-size: 15px;"),
+      icon = shiny::icon(icon_name),
       class = class_name,
       style = "width: 80%; font-weight: bold;"
     )
@@ -31,8 +31,8 @@ amr_button <- function(id, label, icon_name, class_name) {
 #' @keywords internal
 #' @noRd
 styledBox <- function(outputId) {
-  uiOutput(outputId, container = function(...) {
-    div(style = "padding-top: 0px; padding-bottom: 10px; height: 80%", ...)
+  shiny::uiOutput(outputId, container = function(...) {
+    shiny::div(style = "padding-top: 0px; padding-bottom: 10px; height: 80%", ...)
   })
 }
 
@@ -48,11 +48,11 @@ styledBox <- function(outputId) {
 #' @keywords internal
 #' @noRd
 amr_select <- function(id, label, choices, multiple = TRUE, selected = NULL) {
-  div(
+  shiny::div(
     style = "padding: 10px;",
-    selectInput(
+    shiny::selectInput(
       inputId = id,
-      label = tags$label(label, style = "font-size: 15px;"),
+      label = shiny::tags$label(label, style = "font-size: 15px;"),
       choices = choices,
       multiple = multiple,
       selectize = TRUE,


### PR DESCRIPTION
What this does: Swaps the "import everything from shiny" shortcut for spelling out shiny:: on every shiny function call (279 places across the UI files).

Why: Right now nothing breaks, but if we ever add another package that happens to define a function with the same name as a shiny one (like column or div), it could silently override shiny's version and cause a bug that's hard to trace. Being explicit avoids that. This also finishes what PR #52 started.

Tested: Ran the full test suite (passes) and actually launched the dashboard in a headless browser to confirm every tab still loads and works.

Next step: We should add a lint check so this stays consistent going forward instead of relying on people remembering to do it by hand.